### PR TITLE
Feature bp 728 migrate movai classes to use data access layer (#57)

### DIFF
--- a/API2/Application.py
+++ b/API2/Application.py
@@ -1,0 +1,11 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from dal.scopes.application import (Application)
+
+__all__ = ["Application"]

--- a/API2/Callback.py
+++ b/API2/Callback.py
@@ -1,0 +1,12 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from dal.scopes.callback import (Callback)
+
+
+__all__ = ["Callback"]

--- a/API2/Configuration.py
+++ b/API2/Configuration.py
@@ -1,0 +1,14 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from dal.scopes.configuration import (Configuration, Config)
+
+__all__ = [
+    "Configuration",
+    "Config"
+]

--- a/API2/Exceptions.py
+++ b/API2/Exceptions.py
@@ -1,0 +1,24 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from movai_core_shared.exceptions import (
+    MovaiException,
+    DoesNotExist,
+    AlreadyExist,
+    InvalidStructure,
+    TransitionException,
+)
+
+
+__all__ = [
+    "MovaiException",
+    "DoesNotExist",
+    "AlreadyExist",
+    "InvalidStructure",
+    "TransitionException",
+]

--- a/API2/Fleet.py
+++ b/API2/Fleet.py
@@ -1,0 +1,26 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+try:
+    from movai_core_enterprise.scopes.task import Task
+    from movai_core_enterprise.scopes.tasktemplate import TaskTemplate
+    from movai_core_enterprise.scopes.shareddatatemplate import SharedDataTemplate
+    from movai_core_enterprise.scopes.taskentry import TaskEntry
+    from movai_core_enterprise.scopes.shareddataentry import SharedDataEntry
+
+    __all__ = [
+        "Task",
+        "TaskTemplate",
+        "SharedDataTemplate",
+        "TaskEntry",
+        "SharedDataEntry",
+    ]
+    enterprise = True
+except ImportError:
+    __all__ = []
+    enterprise = False

--- a/API2/Flow.py
+++ b/API2/Flow.py
@@ -1,0 +1,12 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from dal.scopes.flow import Flow
+
+
+__all__ = ["Flow"]

--- a/API2/GraphicScene.py
+++ b/API2/GraphicScene.py
@@ -1,0 +1,17 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+try:
+   from movai_core_enterprise.scopes.graphicscene import GraphicScene
+   __all__ = ["GraphicScene"]
+   enterprise = True
+except ImportError:
+   __all__ = []
+   enterprise = False
+
+

--- a/API2/Layer1.py
+++ b/API2/Layer1.py
@@ -1,0 +1,11 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from dal.movaidb import MovaiDB
+
+__all__ = ["MovaiDB"]

--- a/API2/Lock.py
+++ b/API2/Lock.py
@@ -1,0 +1,11 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from dal.models.lock import Lock
+
+__all__ = ["Lock"]

--- a/API2/Message.py
+++ b/API2/Message.py
@@ -1,0 +1,11 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from dal.scopes.message import Message
+
+__all__ = ["Message"]

--- a/API2/Node.py
+++ b/API2/Node.py
@@ -1,0 +1,11 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from dal.scopes.node import Node
+
+__all__ = ["Node"]

--- a/API2/Package.py
+++ b/API2/Package.py
@@ -1,0 +1,11 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from dal.scopes.package import Package
+
+__all__ = ["Package"]

--- a/API2/Redis.py
+++ b/API2/Redis.py
@@ -1,0 +1,25 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from deprecated.api.core.redis import (GDRedis, GDRedisInit, Redis, RedisClient)
+from deprecated.api.core.redis import (REDIS_SLAVE_HOST, REDIS_SLAVE_PORT, REDIS_LOCAL_HOST,
+                            REDIS_LOCAL_PORT, REDIS_MASTER_HOST, REDIS_MASTER_PORT)
+
+
+__all__ = [
+    "GDRedis",
+    "GDRedisInit",
+    "Redis",
+    "RedisClient",
+    "REDIS_SLAVE_HOST",
+    "REDIS_SLAVE_PORT",
+    "REDIS_LOCAL_HOST",
+    "REDIS_LOCAL_PORT",
+    "REDIS_MASTER_HOST",
+    "REDIS_MASTER_PORT"
+]

--- a/API2/Robot.py
+++ b/API2/Robot.py
@@ -1,0 +1,16 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from dal.scopes.robot import Robot
+from dal.scopes.fleetrobot import FleetRobot
+
+
+__all__ = [
+    "Robot",
+    "FleetRobot"
+]

--- a/API2/Role.py
+++ b/API2/Role.py
@@ -1,0 +1,11 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from dal.scopes.role import (Role)
+
+__all__ = ["Role"]

--- a/API2/Scopes.py
+++ b/API2/Scopes.py
@@ -1,0 +1,48 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from dal.helpers import Helpers
+from dal.scopes.application import (Application)
+from dal.scopes.form import (Form)
+from dal.scopes.ports import (Ports)
+from dal.scopes.scope import (Scope)
+from dal.scopes.structures import (List, Hash, Struct)
+from dal.scopes.system import (System)
+from dal.scopes.widget import (Widget)
+
+try:
+    from movai_core_enterprise.scopes.annotation import (Annotation)
+    from movai_core_enterprise.scopes.graphicasset import (GraphicAsset)
+    from movai_core_enterprise.scopes.layout import (Layout)
+    from movai_core_enterprise.scopes.shareddataentry import (SharedDataEntry)
+    from movai_core_enterprise.scopes.shareddatatemplate import (SharedDataTemplate)
+    from movai_core_enterprise.scopes.tasktemplate import (TaskTemplate)
+    enterprise_models = [
+        "Annotation",
+        "GraphicAsset",
+        "Layout",
+        "SharedDataEntry",
+        "SharedDataTemplate",
+        "TaskTemplate",
+    ]
+except ImportError:
+    enterprise_models = []
+
+__all__ = [
+    "Application",
+    "Form",
+    "List",
+    "Hash",
+    "Helpers",
+    "Scope",
+    "Struct",
+    "Widget",
+    "System",
+    "Ports",
+]
+__all__.extend(enterprise_models)

--- a/API2/StateMachine.py
+++ b/API2/StateMachine.py
@@ -1,0 +1,15 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from dal.scopes.statemachine import (StateMachine,SMVars)
+
+
+__all__ = [
+    "StateMachine",
+    "SMVars"
+]

--- a/API2/Var.py
+++ b/API2/Var.py
@@ -1,0 +1,11 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from dal.models.var import (Var)
+
+__all__ = ["Var"]

--- a/API2/__init__.py
+++ b/API2/__init__.py
@@ -1,0 +1,11 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+from movai_core_shared.logger import Log
+LOGGER = Log.get_logger("API2")
+LOGGER.warning(f"DeprecationWarning: \"API2\" module will be deprecated from version Mov.ai 2.2.4, use dal.scopes / dal.models instead")

--- a/dal/classes/protocols/wsredissub.py
+++ b/dal/classes/protocols/wsredissub.py
@@ -16,7 +16,7 @@ import uuid
 import aioredis
 import yaml
 from aiohttp import WSMsgType, web
-import gdnode
+import gd_node
 from movai_core_shared.logger import Log
 from dal.movaidb import MovaiDB, RedisClient
 try:

--- a/dal/classes/utils/secretkey.py
+++ b/dal/classes/utils/secretkey.py
@@ -1,0 +1,121 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Erez Zomer  (erez@mov.ai) - 2022
+"""
+from movai_core_shared.logger import Log
+from movai_core_shared.common.time import current_time_string
+from movai_core_shared.core.secure import generate_secret_string
+from movai_core_shared.exceptions import (
+    SecretKeyAlreadyExist,
+    SecretKeyDoesNotExist
+)
+
+from dal.movaidb import MovaiDB
+
+
+class SecretKey:
+    log = Log.get_logger(__name__)
+    db = MovaiDB(db='global')
+    type_name = 'SecretKey'
+    secret_key_dict = {'KeyLength': '',
+                       'Secret': '',
+                       'LastUpdate': ''}
+
+    @classmethod
+    def _generate_dict(cls, length: int) -> dict:
+        """generate a dictionary with all relevant keys for storing the secret
+        key info in DB.
+
+        Args:
+            length (int): The length of the key.
+
+        Returns:
+            dict: The created dictionary.
+        """
+        cls.secret_key_dict['KeyLength'] = length
+        cls.secret_key_dict['Secret'] = generate_secret_string(length)
+        cls.secret_key_dict['LastUpdate'] = current_time_string()
+        return cls.secret_key_dict
+
+    @classmethod
+    def is_exist(cls, fleet_name: str) -> bool:
+        """checks if a specified key exist in DB.
+
+        Args:
+            fleet_name (str): The name of the fleet which owns the key.
+
+        Returns:
+            bool: True if exist, False otherwise.
+        """
+        secret = cls.db.get_value({cls.type_name: {fleet_name: {'Secret': ''}}})
+        return secret is not None
+
+    @classmethod
+    def create(cls, fleet_name: str, length: int = 32) -> None:
+        """creates a new key in the DB
+
+        Args:
+            fleet_name (str): The name of the fleet which owns the key. 
+            length (int, optional): The length of the key.. Defaults to 32.
+
+        Returns:
+            bool: True if succesfull, False otherwise.
+        """
+        if cls.is_exist(fleet_name):
+            error_msg = f"The secret key {fleet_name} already exist."
+            raise SecretKeyAlreadyExist(error_msg)
+        cls.db.set({cls.type_name: {fleet_name: cls._generate_dict(length)}})
+
+    @classmethod
+    def remove(cls, fleet_name: str) -> None:
+        """Removes a key from the DB.
+
+        Args:
+            fleet_name (str): The name of the fleet which owns the key. 
+
+        Returns:
+            bool: True if succesfull, False otherwise.
+        """
+        if not cls.is_exist(fleet_name):
+            error_msg = f"The secret key {fleet_name} does not exist."
+            cls.log.error(error_msg)
+            raise SecretKeyDoesNotExist(error_msg)
+        cls.db.delete({cls.type_name: {fleet_name: cls.secret_key_dict}})
+
+    @classmethod
+    def update(cls, fleet_name: str, length: int = 32) -> None:
+        """updates an existing key in the DB.
+
+        Args:
+            fleet_name (str): The name of the fleet which owns the key. 
+            length (int, optional): The length of the key.. Defaults to 32.
+
+        Returns:
+            bool: True if succesfull, False otherwise.
+        """
+        if not cls.is_exist(fleet_name):
+            error_msg = f"The secret key {fleet_name} does not exist."
+            cls.log.error(error_msg)
+            raise SecretKeyDoesNotExist(error_msg)
+        cls.db.set({cls.type_name: {fleet_name: cls._generate_dict(length)}})
+
+    @classmethod
+    def get_secret(cls, fleet_name: str) -> str:
+        """returns the secret content.
+
+        Args:
+            fleet_name (str): The name of the fleet which owns the key.
+
+        Returns:
+            str: The secret.
+        """
+        if not cls.is_exist(fleet_name):
+            error_msg = f"The secret key {fleet_name} does not exist."
+            cls.log.error(error_msg)
+            raise SecretKeyDoesNotExist(error_msg)
+        secret = cls.db.get_value({cls.type_name: {fleet_name: {'Secret': ''}}})
+        return secret

--- a/dal/classes/utils/token.py
+++ b/dal/classes/utils/token.py
@@ -1,0 +1,432 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Erez Zomer  (erez@mov.ai) - 2022
+"""
+from socket import gethostname
+import uuid
+import jwt
+from datetime import timedelta
+
+from movai_core_shared.logger import Log
+from movai_core_shared.common.time import current_timestamp_int, delta_time_int
+
+from movai_core_shared.exceptions import (
+    InvalidToken,
+    TokenError,
+    TokenExpired,
+    TokenRevoked,
+    UserError,
+)
+
+from dal.movaidb import MovaiDB
+from dal.models.baseuser import BaseUser
+
+from dal.data.shared.vault import (
+    JWT_SECRET_KEY,
+    JWT_ACCESS_EXPIRATION_DELTA,
+    JWT_REFRESH_EXPIRATION_DELTA,
+)
+
+
+class TokenObject:
+    """An object for refercing token info with object attributes."""
+
+    def __init__(self, token: dict) -> None:
+        """Initializes the object.
+
+        Args:
+            token (dict): a dictionary with the token info.
+
+        Raises:
+            InvalidToken: In case there are missing keys.
+        """
+        try:
+            self.subject = token["sub"]
+            self.issuer = token["iss"]
+            self.issue_time = token["iat"]
+            self.expiration_time = token["exp"]
+            self.jwt_id = token["jti"]
+            if "refresh_id" in token:
+                self.refresh_id = token["refresh_id"]
+        except KeyError:
+            error_msg = f"Token has missing key"
+            raise InvalidToken(error_msg)
+
+
+class UserTokenObject(TokenObject):
+    """Extends the Token object with more attributes relating to user tokens."""
+
+    def __init__(self, token: dict) -> None:
+        """Initializes the object.
+
+        Args:
+            token (dict): A dictionary with the user token info.
+        """
+        super().__init__(token)
+        self.account_name = token["account_name"]
+        self.domain_name = token["domain_name"]
+        self.common_name = token["common_name"]
+        self.user_type = token["user_type"]
+        self.roles = token["roles"]
+        self.email = token["email"]
+        self.super_user = token["super_user"]
+        self.read_only = token["read_only"]
+        self.send_report = token["send_report"]
+
+
+class DBToken(dict):
+    def __init__(self, token: TokenObject, token_type: str = "Token"):
+        super().__init__()
+        self[token_type] = {token.jwt_id: {"ExpirationTime": token.expiration_time}}
+
+
+class EmptyDBToken(dict):
+    def __init__(self, token_id: str = None, token_type: str = "Token"):
+        super().__init__()
+        if token_id is None:
+            self[token_type] = {"*": {"ExpirationTime": ""}}
+        else:
+            self[token_type] = {token_id: {"ExpirationTime": ""}}
+
+
+class TokenManager:
+    """A general class for managing tokens in DB."""
+
+    log = Log.get_logger('TokenManger')
+    db = MovaiDB(db="local")
+    token_type = "Token"
+
+    @classmethod
+    def is_token_exist(cls, token_id: str) -> bool:
+        """Checks whether a specific token exist in the DB.
+
+        Args:
+            token (TokenObject): The token to look for.
+
+        Returns:
+            bool: True if exist, False otherwise.
+        """
+        result = cls.db.get(EmptyDBToken(token_id))
+        return len(result.keys()) > 0
+
+    @classmethod
+    def remove_token(cls, token_id: str) -> None:
+        """Removes token scheme from DB by the Token id.
+
+        Args:
+            token (TokenObject): The token to remove.
+        """
+        if cls.is_token_exist(token_id):
+            cls.db.delete(EmptyDBToken(token_id))
+            cls.log.debug(
+                f"The token id {token_id} has been removed from the allowed token list."
+            )
+
+    @classmethod
+    def store_token(cls, token: TokenObject) -> None:
+        """Stors a token in the DB.
+
+        Args:
+            token (TokenObject): The token to store.
+        """
+        cls.db.set(DBToken(token))
+        cls.log.debug(
+            f"The token id {token.jwt_id} has been added to the allowed token list."
+        )
+
+    @classmethod
+    def remove_all_tokens(cls):
+        """Removes all token from db.
+        """
+        cls.log.info(f"Removing all tokens from token list.")
+        tokens = cls.db.get(EmptyDBToken(None, cls.token_type))
+        tokens = tokens.get(cls.token_type)
+        if tokens is not None:
+            for token_id in tokens.keys():
+                cls.remove_token(token_id)
+
+    @classmethod
+    def remove_all_expired_tokens(cls):
+        """Removes all the tokens that their expiration
+        time has passed.
+        """
+        cls.log.info(f"Removing all expired tokens.")
+        tokens = cls.db.get(EmptyDBToken(None, cls.token_type))
+        tokens = tokens.get(cls.token_type)
+        current_time = current_timestamp_int()
+        if tokens is not None:
+            for token_id, token_data in tokens.items():
+                if token_data["ExpirationTime"] < current_time:
+                    cls.remove_token(token_id)
+
+class Token:
+    allowed_algorithms = ["HS256", "RS256", "ES256"]
+    required_keys = set(["sub", "iss", "iat", "exp", "jti"])
+    log = Log.get_logger('Token')
+    _token_manager = TokenManager
+    _issuer = gethostname()
+
+    @classmethod
+    def get_token_id(cls, token: str):
+        return TokenObject(cls.decode_no_verify_token(token)).jwt_id
+
+    @classmethod
+    def init_payload(cls, subject: str, expiration_delta: timedelta) -> dict:
+        """initializes a dictionary which will be used as a payload
+        for token (JWT) generation.
+
+        Args:
+            subject (str): The subject of the token ('Access', 'Refresh')
+            expiration_delta (timedelta): the time delta from now.
+        
+        Returns:
+            (dict): the payload of the token.
+        """
+        cls.log.debug(f"Initializing token payload.")
+        payload = {}
+        payload["sub"] = subject
+        payload["iss"] = cls._issuer
+        payload["iat"] = current_timestamp_int()
+        payload["exp"] = delta_time_int(expiration_delta)
+        payload["jti"] = str(uuid.uuid4())
+        return payload
+
+    @classmethod
+    def decode_and_verify_token(cls, token: str, secret_key=JWT_SECRET_KEY) -> dict:
+        """This function verifies and decodes the token, the decoded token
+        is returned in a dictionary with meaninigfull keys. if verification fails
+        an Exception would be returned.
+
+        Args:
+            token (str): a string representing the token (encoded JWT).
+            secret_key (str): The key used to encrypt the data. Defaults
+                to JWT_SECRET_KEY.
+
+        Raises:
+            wt.exceptions.InvalidTokenError: In case token verification fails.
+
+        Returns:
+            dict: a dicitionary with all the token's payload info.
+        """
+        #cls.log.debug(f"Decoding and verifying token.")
+        options = {}
+        options["require"] = cls.required_keys
+        options["verify_iss"] = True
+        token_payload = jwt.decode(jwt=token, key=secret_key, algorithms=cls.allowed_algorithms, options=options)
+        return token_payload
+
+    @classmethod
+    def decode_no_verify_token(cls, token: str, secret_key=JWT_SECRET_KEY) -> dict:
+        """This function decodes the token withoud verifying it, the decoded token
+        is returned in a dictionary with meaninigfull keys.
+
+        Args:
+            token (str): a string representing the token (encoded JWT).
+            secret_key (str): The key used to verify token signature. Defaults
+                to JWT_SECRET_KEY.
+
+        Returns:
+            dict: A dicitionary with all the token's payload info.
+        """
+        #cls.log.debug(f"Decoding token without verification.")
+        return jwt.decode(
+            jwt=token, key=secret_key, verify=False, algorithms=cls.allowed_algorithms
+        )
+
+    @classmethod
+    def encode_token(cls, token_payload: dict, secret_key: str = JWT_SECRET_KEY, algorithm: str = "HS256") -> str:
+        """This function generates Json Web Token (JWT) that will use the
+        client to access system resources.
+
+        Args:
+            token_payload (dict): A dictionary containing the payload values.
+            secret_key (str): The key used to sign token signature. Defaults
+                to JWT_SECRET_KEY.
+            algorithm (str, optional): The signing algorithm to use. Defaults to 'HS256'.
+
+        Raises:
+            TokenError: In case the requested algorithm is not found on the allowed algorithms set.
+            TokenError: In case the one of the required keys is not found in the token.
+
+        Returns:
+            str: The encoded token.
+        """
+        if algorithm not in cls.allowed_algorithms:
+            error_msg = f"The algorithm {algorithm} is not allowed for encoding tokens."
+            raise TokenError(error_msg)
+
+        for key in Token.required_keys:
+           if key not in token_payload.keys():
+               error_msg = f"The key: \"{key}\" is missing from payload dictionary."
+               raise TokenError(error_msg)
+        cls.log.debug(f"Encoding token using {algorithm} algorithm.")
+        token_str = jwt.encode(payload=token_payload, key=secret_key, algorithm=algorithm).decode("utf-8")
+        return token_str
+
+    @classmethod
+    def verify_token(cls, token: str) -> None:
+        """verifies the token validity
+
+        Args:
+            token (str): The string representation of the token.
+
+        Raises:
+            TokenRevoked: In case the token was revoked from the DB.
+            TokenExpired: In case the token expiration time has expired.
+            InvalidToken: In case there is decode error
+            InvalidToken: In case the token is invalid.
+        """
+        if not isinstance(token, str):
+            error_msg = "Token must be a string!"
+            raise TokenError(error_msg)
+        try:
+            token_id = cls.get_token_id(token)
+            #cls.log.debug(f"Verifying token id {token_id}")
+            cls.decode_and_verify_token(token)
+            if not cls._token_manager.is_token_exist(token_id):
+                error_msg = "Token have been revoked, please login again."
+                raise TokenRevoked(error_msg)
+        except (jwt.ExpiredSignatureError, jwt.DecodeError, jwt.InvalidTokenError)  as e:
+            error_msg = f"Failed to verify token: {e}"
+            cls.log.warning(error_msg)
+            cls._token_manager.remove_token(token_id)
+            raise TokenExpired(error_msg)
+
+    @classmethod
+    def get_token_obj(cls, token: str) -> TokenObject:
+        """Extracts the token and returns a TokenObject.
+        Args:
+            token (str): the token to extract.
+
+        Returns:
+            TokenObject: The token info wrapped in an object.
+        """
+        return TokenObject(cls.decode_no_verify_token(token))
+
+    @classmethod
+    def revoke_token(cls, token: str) -> None:
+        """Removes the token id from the allowed token list.
+        If the token has a refresh_id token it will remove the refresh_id token as well.
+
+        Args:
+            token (str): The token to revoke.
+        """
+        token_obj = cls.get_token_obj(token)
+        cls._token_manager.remove_token(token_obj.jwt_id)
+        cls._token_manager.remove_token(token_obj.refresh_id)
+
+
+class UserToken(Token):
+    @classmethod
+    def init_payload(cls, user: BaseUser, subject: str, expiration_delta: timedelta, refresh_id: str) -> None:
+        """initializes a dictionary which will be used as a payload
+        for token (JWT) generation.
+
+        Args:
+            user: (BaseUser): The user to for whom the token will be generated.
+            expiration_delta (timedelta): the time delta from now.
+            refresh_id (str): An id of the assciated refresh token.
+        
+        Returns:
+            (dict): The dictionary to use as a payload when encoding the token.
+        """
+        payload = super().init_payload(subject, expiration_delta)
+        payload["refresh_id"] = refresh_id
+        payload["domain_name"] = user.domain_name
+        payload["account_name"] = user.account_name
+        payload["common_name"] = user.common_name
+        payload["user_type"] = user.user_type
+        payload["roles"] = user.Roles
+        payload["email"] = user.email
+        payload["super_user"] = user.super_user
+        payload["read_only"] = user.read_only
+        payload["send_report"] = user.send_report
+        return payload
+
+    @classmethod
+    def get_token_obj(cls, token: str) -> UserTokenObject:
+        """Extracts the token and returns a UserTokenObject.
+
+        Args:
+            token (str): the token to extract.
+
+        Returns:
+            UserTokenObject: The token info wrapped in an object.
+        """
+        return UserTokenObject(cls.decode_no_verify_token(token))
+
+    @classmethod
+    def get_refresh_id(cls, token: str) -> str:
+        """Returns the refresh_id of the token if exist.
+
+        Args:
+            token (str): The token where refresh_id is specified.
+
+        Returns:
+            str: The refresh_id if exists, None otherwise.
+        """
+        token_obj = cls.get_token_obj(token)
+        if "" == token_obj.refresh_id:
+            return None
+        return token_obj.refresh_id
+            
+            
+    @classmethod
+    def _generate_user_token(
+        cls, user: BaseUser, subject: str, time_delta: timedelta, refresh_id: str = ""
+    ) -> str:
+        """This function encapsulates the generate_token function to
+        generate the access token.
+        
+        Args:
+            user (BaseUser): The user for whom the token is generated.
+            subect (str): The subject of the token ('Access', 'Refresh').
+            time_delta (timedelta): The time difference between issue time to
+                expiration time.
+            refresh_id (str): The id of the associated refresh token. Defaults to
+                empty string.
+
+        Returns:
+            str: The generated token decoded in utf-8.
+        """
+        if not isinstance(user, BaseUser):
+            error_msg = f"The user argument is from unknown type."
+            raise UserError(error_msg)
+        token_payload = cls.init_payload(user, subject, time_delta, refresh_id)
+        token_str = cls.encode_token(token_payload)
+        cls._token_manager.store_token(UserTokenObject(token_payload))
+        return token_str
+
+    @classmethod
+    def generate_access_token(cls, user: BaseUser, refresh_id) -> str:
+        """This function encapsulates the generate_token function to
+        generate the access token.
+
+        Args:
+            user (BaseUser): The user for whom the token is generated.
+            refresh_id (str): The id of the associated refresh token. Defaults to
+                empty string.
+
+        Returns:
+            str: The generated token decoded in utf-8.
+        """
+        return cls._generate_user_token(user, "Access", JWT_ACCESS_EXPIRATION_DELTA, refresh_id)
+
+    @classmethod
+    def generate_refresh_token(cls, user: BaseUser) -> str:
+        """This function encapsulates the generate_token function to
+        generate the refresh token.
+
+        Args:
+            user (BaseUser): The user for whom the token is generated.
+
+        Returns:
+            str: The generated token decoded in utf-8.
+        """
+        return cls._generate_user_token(user, "Refresh", JWT_REFRESH_EXPIRATION_DELTA)
+
+ 

--- a/dal/data/archive.py
+++ b/dal/data/archive.py
@@ -1,0 +1,217 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
+"""
+import asyncio
+import os
+from aiohttp import ClientSession
+from aiohttp.client import ContentTypeError, ClientConnectorError
+from yarl import URL
+
+CHUNK_SIZE = 4 * 1024  # 4 KB
+
+
+class RemoteArchiveAsync:
+    """
+    This class implements a remote archive client
+    It's used for the command line tool and also for
+    the filesystem to fetch missing data
+    """
+
+    def __init__(self, remote_uri: URL, user: str, password: str):
+        self._remote_uri = remote_uri
+        self._user = user
+        self._password = password
+        self._access_token = None
+
+    def _make_url(self, path: str) -> URL:
+        return self._remote_uri / path
+
+    async def _authenticate(self):
+        """
+        Authenticate against the server
+        """
+        async with ClientSession() as session:
+            async with session.post(self._make_url("token-auth/"), json={
+                "username": self._user,
+                "password": self._password
+            }) as response:
+
+                body = await response.json()
+                self._access_token = body["access_token"]
+
+    async def list_scopes(self, workspace_id: str):
+        """
+        List scopes in a workspace
+        """
+        try:
+            await self._authenticate()
+            async with ClientSession(headers={"Authorization": f"Bearer {self._access_token}"}) as session:
+                async with session.get(self._make_url(f"api/v2/db/{workspace_id}")) as response:
+                    return await response.json()
+        except (ContentTypeError, ClientConnectorError):
+            return {}
+
+    async def list_workspaces(self):
+        """
+        List available workspaces
+        """
+        try:
+            await self._authenticate()
+            async with ClientSession(headers={"Authorization": f"Bearer {self._access_token}"}) as session:
+                async with session.get(self._make_url("api/v2/db")) as response:
+                    return await response.json()
+        except (ContentTypeError, ClientConnectorError):
+            return {}
+
+    async def get_scope(self, path: str):
+        """
+        List available workspaces
+        """
+        try:
+            await self._authenticate()
+            async with ClientSession(headers={"Authorization": f"Bearer {self._access_token}"}) as session:
+                async with session.get(self._make_url(f"api/v2/db/{path}")) as response:
+                    return await response.json()
+        except (ContentTypeError, ClientConnectorError):
+            return {}
+
+    async def backup(self, objs: object, destination: str):
+        """
+        Download a scope
+        """
+        try:
+            await self._authenticate()
+            async with ClientSession(headers={"Authorization": f"Bearer {self._access_token}"}) as session:
+
+                # First we create the backup job with the scope
+                # we want to download
+                async with session.post(self._make_url("api/v2/db/backup"), json={
+                    "metadata": {},
+                    "manifest": objs if isinstance(objs, list) else [str(objs)]
+                }) as response:
+
+                    job = await response.json()
+
+                # get the id of the backup job and current state
+                try:
+                    job_id = job["id"]
+                    current_state = job["state"]["state"]
+                except KeyError:
+                    return False
+
+                # we wait until the job is finished
+                while current_state != "finished":
+                    async with session.get(self._make_url(f"api/v2/db/backup/{job_id}")) as response:
+                        job_info = await response.json()
+                        try:
+                            current_state = job_info["state"]["state"]
+                        except KeyError:
+                            return False
+
+                # Download the backup file to a temporary folder
+                try:
+                    os.makedirs(os.path.dirname(destination), exist_ok=True)
+                except PermissionError:
+                    return False
+                except FileNotFoundError:
+                    pass
+
+                async with session.get(self._make_url(f"api/v2/db/backup/{job_id}/archive")) as response:
+                    # Read the content from the request
+                    with open(destination, 'wb') as backup_fp:
+                        while True:
+                            chunk = await response.content.read(CHUNK_SIZE)
+                            if not chunk:
+                                break
+                            backup_fp.write(chunk)
+
+                return True
+
+        except (ContentTypeError, ClientConnectorError):
+            return False
+
+    async def restore(self, source: str):
+        """
+        Upload a restore file to the server
+        """
+        try:
+
+            if not os.path.exists(source):
+                return False
+
+            await self._authenticate()
+            async with ClientSession(headers={"Authorization": f"Bearer {self._access_token}"}) as session:
+
+                # We open the restore file and upload it to the server
+                with open(source, "rb") as restore_fp:
+                    async with session.post(self._make_url("api/v2/db/restore"), data=restore_fp) as response:
+                        job = await response.json()
+
+                # get the id of the backup job and current state
+                try:
+                    job_id = job["id"]
+                    current_state = job["state"]["state"]
+                except KeyError:
+                    return False
+
+                # we wait until the job is finished
+                while current_state != "finished":
+                    async with session.get(self._make_url(f"api/v2/db/restore/{job_id}")) as response:
+                        job_info = await response.json()
+                        try:
+                            current_state = job_info["state"]["state"]
+                        except KeyError:
+                            return False
+
+                return True
+
+        except (ContentTypeError, ClientConnectorError):
+            return False
+
+
+class RemoteArchive:
+    """
+    A helper class that encapsulates the async code
+    """
+
+    def __init__(self, remote_uri: str, user: str, password: str):
+        self._async_client = RemoteArchiveAsync(
+            URL(remote_uri), user, password)
+        self._loop = asyncio.get_event_loop()
+
+    def list_scopes(self, workspace_id: str):
+        """
+        Get a list of all scopes in a workspace
+        """
+        return self._loop.run_until_complete(self._async_client.list_scopes(workspace_id))
+
+    def list_workspaces(self):
+        """
+        Get a list of all workspaces
+        """
+        return self._loop.run_until_complete(self._async_client.list_workspaces())
+
+    def get_scope(self, path: str):
+        """
+        Get a scope
+        """
+        return self._loop.run_until_complete(self._async_client.get_scope(path))
+
+    def backup(self, objs: object, dst: str):
+        """
+        Backup scopes and dependencies
+        objs - a list of the objects to backup
+        """
+        return self._loop.run_until_complete(self._async_client.backup(objs, dst))
+
+    def restore(self, source: str):
+        """
+        Restore scopes
+        source - the restore file
+        """
+        return self._loop.run_until_complete(self._async_client.restore(source))

--- a/dal/data/persistence.py
+++ b/dal/data/persistence.py
@@ -8,7 +8,7 @@
 """
 from abc import ABC, abstractmethod, abstractproperty
 from movai_core_shared.logger import Log
-from dal.plugins import Plugin, PluginManager
+from dal.plugins.plugin import Plugin, PluginManager
 
 
 class PersistentObject(ABC):

--- a/dal/data/shared/vault.py
+++ b/dal/data/shared/vault.py
@@ -1,0 +1,12 @@
+from datetime import timedelta
+
+from movai_core_shared.envvars import (FLEET_NAME,
+                                       DEFAULT_JWT_ACCESS_DELTA_SECS,
+                                       DEFAULT_JWT_REFRESH_DELTA_DAYS)
+
+from dal.classes.utils.secretkey import SecretKey
+
+# JWT Authentication
+JWT_SECRET_KEY = SecretKey.get_secret(FLEET_NAME)
+JWT_ACCESS_EXPIRATION_DELTA = timedelta(seconds=DEFAULT_JWT_ACCESS_DELTA_SECS)
+JWT_REFRESH_EXPIRATION_DELTA = timedelta(days=DEFAULT_JWT_REFRESH_DELTA_DAYS)

--- a/dal/models/acl.py
+++ b/dal/models/acl.py
@@ -9,119 +9,174 @@
 """
 
 from typing import List, Dict
+
 from miracle import Acl
+
 from movai_core_shared.envvars import REST_SCOPES
 from movai_core_shared.logger import Log
 from .scopestree import scopes
-
-LOGGER = Log.get_logger(".mov.ai")
 
 
 class ACLManager:
     """
     Acl class to manage users and roles permissions
     """
-    _DEFAULT_PERMISSIONS = ['create', 'read', 'update', 'delete']
-    _EXECUTE_PERMISSIONS = _DEFAULT_PERMISSIONS + ['execute']
+
+    log = Log.get_logger("ACLManager")
+    _DEFAULT_PERMISSIONS = ["create", "read", "update", "delete"]
+    _EXECUTE_PERMISSIONS = _DEFAULT_PERMISSIONS + ["execute"]
+    _USER_PERMISSIONS = _DEFAULT_PERMISSIONS + ["reset"]
     _SPECIAL_PERMISSIONS_MAP = {
-        'Application': _EXECUTE_PERMISSIONS,
-        'Callback': _EXECUTE_PERMISSIONS,
-        'User': []  # no permissions
+        "Application": _EXECUTE_PERMISSIONS,
+        "Callback": _EXECUTE_PERMISSIONS,
+        "User": ["read"],
+        "InternalUser": _USER_PERMISSIONS,
     }
 
     def __init__(self, user):
         self.user = user
 
     def get_acl(self) -> object:
-        """ Setup ACL for the current user role and user resources """
+        """Setup ACL for the current user role and user resources"""
         acl = Acl()
         try:
-            role = scopes.from_path(self.user.Role, scope='Role')
+            role = scopes.from_path(self.user.Role, scope="Role")
         except Exception as e:
-            LOGGER.warning("Invalid User Role: {}".format(str(e)))
+            self.log.warning("Invalid User Role: {}".format(str(e)))
             return acl
 
         user_resources = self.user.Resources
 
         # Setup user role resources
         for (resource_key, resource_value) in role.Resources.items():
-            acl.grants({
-                role.ref: {
-                    resource_key: resource_value if resource_value else [],
-                },
-            })
+            acl.grants(
+                {
+                    role.ref: {
+                        resource_key: resource_value if resource_value else [],
+                    },
+                }
+            )
 
         # Setup user resources
         for (resource_key, resource_value) in user_resources.items():
 
-            if resource_key[:1] == '-':
+            if resource_key[:1] == "-":
                 acl.revoke_all(role.ref, resource_key[1:])
                 continue
 
             for perm in resource_value:
-                if perm[:1] == '-':
+                if perm[:1] == "-":
                     acl.revoke(role.ref, resource_key, perm[1:])
-                elif perm[:1] == '+':
+                elif perm[:1] == "+":
                     acl.grant(role.ref, resource_key, perm[1:])
                 else:
                     acl.grant(role.ref, resource_key, perm)
 
         return acl
 
-    def set_user_role(self, role_name: str) -> bool:
-        """ Set the User Role
-
-            This doesn't save in storage, use User.write to save
-        """
-        try:
-            # just to check if exists
-            self.user.Role = scopes.from_path(role_name, scope='Role').ref
-            return True
-        except Exception as e:
-            print(e)
-            return False
-
     @staticmethod
     def get_resources() -> List:
-        """ :returns list with available resources """
+        """:returns list with available resources"""
 
-        resources = REST_SCOPES.strip('()').split('|')
+        resources = REST_SCOPES.strip("()").split("|")
 
         # FIXME find a way to list scopes
 
-        # Append 'Applications' resources
-        resources.append('Applications')
+        # Append 'Applications' resource
+        resources.append("Applications")
 
         return resources
 
     @staticmethod
     def get_permissions() -> Dict:
-        """ :returns dict with available resources & permissions """
+        """:returns dict with available resources & permissions"""
 
         resources = ACLManager.get_resources()
         resources_permissions = {}
         # Scopes
         for scope in resources:
             try:
-                resources_permissions[scope] = ACLManager._SPECIAL_PERMISSIONS_MAP[scope]
+                resources_permissions[scope] = ACLManager._SPECIAL_PERMISSIONS_MAP[
+                    scope
+                ]
             except KeyError:
                 resources_permissions[scope] = ACLManager._DEFAULT_PERMISSIONS
 
         # Applications
-        resources_permissions['Applications'] = [
-            item['ref']
-            for item in scopes().list_scopes(scope='Application')
+        resources_permissions["Applications"] = [
+            item["ref"] for item in scopes().list_scopes(scope="Application")
         ]
 
         return resources_permissions
 
     @staticmethod
     def get_roles() -> Dict:
-        """ returns dict with available roles
+        """Returns dict with available roles.
 
-            this has just a tiny little interface to keep this function alive
-
-            use scopes().list_scopes(scope='Role') to get an actual list of scopes
+        Returns:
+            Dict: a dict with all availabe roles in the system.
         """
         # FIXME this may be not the way they intend to use
         return scopes().Role
+
+
+class NewACLManager(ACLManager):
+    def __init__(self, user):
+        """This function initializes the object.
+
+        Args:
+            user (BaseUser): the user to manage permissions for.
+        """
+        self.user = user
+
+    def get_acl(self) -> Acl:
+        """Setup ACL for the current user role.
+
+        Returns:
+            Acl: the object which holds the access list for the user.
+        """
+        acl = Acl()
+        try:
+            for role_name in self.user.roles:
+                role_obj = ScopesTree().from_path(role_name, scope="Role")
+
+                # Setup user role resources
+                for (resource_key, resource_value) in role_obj.Resources.items():
+                    acl.grants({role_name: {resource_key: resource_value}})
+        except Exception as e:
+            self.log.warning("Invalid User Role: {}".format(str(e)))
+            return acl
+
+        return acl
+
+    @staticmethod
+    def get_resources() -> List:
+        """:returns list with available resources"""
+
+        resources = ACLManager.get_resources()
+        resources.extend(
+            ["Role", "InternalUser", "RemoteUser", "AclObject", "LdapConfig"]
+        )
+        return resources
+
+    @staticmethod
+    def get_permissions() -> Dict:
+        """:returns dict with available resources & permissions"""
+
+        resources = NewACLManager.get_resources()
+        resources_permissions = {}
+        # Scopes
+        for scope in resources:
+            try:
+                resources_permissions[scope] = NewACLManager._SPECIAL_PERMISSIONS_MAP[
+                    scope
+                ]
+            except KeyError:
+                resources_permissions[scope] = NewACLManager._DEFAULT_PERMISSIONS
+
+        # Applications
+        resources_permissions["Applications"] = [
+            item["ref"] for item in scopes().list_scopes(scope="Application")
+        ]
+
+        return resources_permissions

--- a/dal/models/aclobject.py
+++ b/dal/models/aclobject.py
@@ -8,7 +8,7 @@ from movai_core_shared.exceptions import (
     AclObjectIDMismatch,
     AclObjectInvalidAttribute)
 from dal.models.model import Model
-from dal.scopes.scopestree import ScopesTree, scopes
+from dal.models.scopestree import ScopesTree, scopes
 
 
 

--- a/dal/models/baseuser.py
+++ b/dal/models/baseuser.py
@@ -1,0 +1,580 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Erez Zomer  (erez@mov.ai) - 2022
+"""
+from typing import List
+from datetime import datetime
+
+from movai_core_shared.utils.principal_name import create_principal_name
+from movai_core_shared.exceptions import (
+    InvalidStructure,
+    UserAlreadyExist,
+    UserDoesNotExist,
+    UserPermissionsError,
+)
+
+from dal.models.scopestree import ScopesTree, scopes
+from dal.models.model import Model
+from dal.models.acl import NewACLManager
+
+
+class BaseUser(Model):
+    """The BaseUser is the base class for user methods, so that
+    RemoteUser and InternalUser can share the same interface.
+    """
+
+    max_attr_length = 100
+    update_keys = {
+        "CommonName",
+        "Roles",
+        "Email",
+        "SuperUser",
+        "ReadOnly",
+        "SendReport",
+    }
+
+    def __init__(self, *args, **kwargs):
+        """initilizes the class"""
+        super().__init__(*args, **kwargs)
+        self._acl = None
+
+    @classmethod
+    def create(
+        cls,
+        domain_name: str,
+        account_name: str,
+        common_name: str,
+        user_type: str,
+        roles: list,
+        email: str = "",
+        super_user: bool = False,
+        read_only: bool = False,
+        send_report: bool = False,
+    ) -> Model:
+        """Create a new BaseUser
+
+        Args:
+            domain (Str): the name of the domain the base user represents.
+            username (str): the name of the base user to create.
+            common_name: (str): a display name for the new user.
+            type: (str): the type of user (INTERNAL, LDAP, PAM).
+            roles: (list): list of roles which are associated with the user.
+            email: (str): the email address of the user.
+            super_user (bool): a flag which represents if the user
+                is super user.
+            read_only (bool): a flag which represents if the user has
+                read only permissions.
+            send_report (bool): a flag which represents if the user is allowed
+                to send reports.
+
+        Raises:
+            ValueError: if domain_name or account_name aren't of type str.
+            ValueError: if account_name is empty string.
+            ValueError: if supplied roles are not in a list format.
+
+        returns:
+            (BaseUser): a refererance to the BaseUser object that was
+            created.
+        """
+        if not isinstance(domain_name, str) or not isinstance(account_name, str):
+            error_msg = "credentials are in unknown format"
+            cls.log.error(error_msg)
+            raise ValueError(error_msg)
+        if account_name == "":
+            error_msg = "account_name is invalid"
+            cls.log.error(error_msg)
+            raise ValueError(error_msg)
+        if not isinstance(roles, list):
+            error_msg = "roles are not in a list format"
+            cls.log.error(error_msg)
+            raise ValueError(error_msg)
+        if cls.is_exist(domain_name, account_name):
+            error_msg = (
+                f"The requested user {account_name}@{domain_name} " "already exist"
+            )
+            raise UserAlreadyExist(error_msg)
+
+        principal_name = create_principal_name(domain_name, account_name)
+        user = scopes().create(scope=cls.__name__, ref=principal_name)
+        user.domain_name = domain_name
+        user.account_name = account_name
+        user.common_name = common_name
+        user.user_type = user_type
+        user.roles = roles
+        user.email = email
+        user.super_user = super_user
+        user.read_only = read_only
+        user.send_report = send_report
+        user.write()
+        msg = f"Successfully created new {cls.__name__} named:" f"{principal_name}"
+        cls.log.info(msg)
+        return user
+
+    @classmethod
+    def remove(cls, domain_name: str, account_name: str) -> None:
+        """removes a User record from DB
+
+        Args:
+        domain_name (str): the name of the domain which the user belongs to.
+        account_name (str): the account name of the user to remove.
+
+        Returns:
+            (bool): True if user got removed, False if user was not found.
+        """
+        principal_name = create_principal_name(domain_name, account_name)
+        user = cls.get_user_by_principal_name(principal_name)
+        account_name = user.account_name
+        scopes().delete(user)
+        cls.log.info(f"User named {account_name} has been removed")
+
+    def update(self, user_params: dict):
+        """This function updates a corresponding object's attributes.
+
+        Args:
+            user_params (dict): a dictionary with the required fields that
+                needs an update.
+
+        Raises:
+            InvalidStructure: in case non of fields sent are part of the
+                InternalUser model.
+        """
+        if not any(key in user_params.keys() for key in self.update_keys):
+            error_msg = (
+                f"Json fields aren't found in " f"{self.__class__.__name__} attributes."
+            )
+            self.log.warning(error_msg)
+            raise InvalidStructure(error_msg)
+        self.common_name = user_params.get("CommonName", self.common_name)
+        self.roles = user_params.get("Roles", self.roles)
+        self.email = user_params.get("Email", self.email)
+        self.super_user = user_params.get("SuperUser", self.super_user)
+        self.read_only = user_params.get("ReadOnly", self.read_only)
+        self.send_report = user_params.get("SendReport", self.send_report)
+        self.write()
+
+    @property
+    def principal_name(self) -> str:
+        """build principal name -> "account_name@domain_name
+
+        Args:
+        domain_name (str): the name of the domain which the user belongs to.
+        account_name (str): the account name of the user.
+
+        Returns:
+            str: the name in the form account_name@domain_name
+        """
+        principal_name = self.account_name + "@" + self.domain_name
+        return principal_name
+
+    @property
+    def domain_name(self) -> str:
+        """returns the domain name of base user.
+
+        Returns:
+            (str): the domain name (e.g: "example.com")
+        """
+        domain_name = str(self.DomainName)
+        return domain_name
+
+    @domain_name.setter
+    def domain_name(self, name) -> None:
+        """returns the domain name of base user.
+
+        Raises:
+            (ValueError): if name arg is not a string.
+        """
+        if not isinstance(name, str):
+            raise ValueError("The name agrument must be a string")
+        self.DomainName = name
+
+    @property
+    def account_name(self) -> str:
+        """returns the account name of base user.
+
+        Returns:
+            (str): the account name (e.g: "johns")
+        """
+        account_name = str(self.AccountName)
+        return account_name
+
+    @account_name.setter
+    def account_name(self, name: str) -> None:
+        """sets the account name of base user.
+
+        Raises:
+            (ValueError): if name arg is not a string.
+        """
+        if not isinstance(name, str):
+            raise ValueError("The name agrument must be a string")
+        self.AccountName = name
+
+    @property
+    def common_name(self) -> str:
+        """returns the common name of base user.
+
+        Returns:
+            (str): the common name (e.g: "John Smith")
+        """
+        common_name = str(self.CommonName)
+        return common_name
+
+    @common_name.setter
+    def common_name(self, name: str) -> None:
+        """sets the value of the common_name property.
+
+        Raises:
+            ValueError: if supplied argument is not in the correct type.
+        """
+        if not isinstance(name, str):
+            raise ValueError("The name agrument must be a string")
+        if len(name) > self.max_attr_length:
+            raise ValueError(
+                f"The name agrument must be less than " f"{self.max_attr_length}"
+            )
+        self.CommonName = name
+
+    @property
+    def user_type(self) -> str:
+        """returns the type of the base user.
+
+        Returns:
+            (str): the type (LDAP, PAM)
+        """
+        user_type = str(self.UserType)
+        return user_type
+
+    @user_type.setter
+    def user_type(self, user_type) -> None:
+        """returns the type of the base user.
+
+        Raises:
+            ValueError: if supplied argument is not in the correct type.
+        """
+        if not isinstance(user_type, str):
+            raise ValueError("The name agrument must be a string")
+        self.UserType = user_type
+
+    @property
+    def email(self) -> str:
+        """returns the email of the base user.
+
+        Returns:
+            (str): the email address (e.g: "johns@example.com")
+        """
+        email = str(self.Email)
+        return email
+
+    @email.setter
+    def email(self, address: str) -> None:
+        """sets the value of the email property.
+
+        Raises:
+            ValueError: if supplied argument is not in the correct type.
+        """
+        if not isinstance(address, str):
+            raise ValueError("The address agrument must be a string")
+        if len(address) > self.max_attr_length:
+            raise ValueError(
+                f"The address agrument must be less " f"than {self.max_attr_length}"
+            )
+        self.Email = address
+
+    @property
+    def roles(self) -> List[str]:
+        """This funtion returns the corresponding role of the user.
+
+        Returns:
+            Union[Model, None]: a Role object or None if it not found.
+        """
+        roles = []
+        if self.Roles is None:
+            return None
+        try:
+            for role in self.Roles:
+                roles.append(str(role))
+            return roles
+        except KeyError:
+            return None
+
+    @roles.setter
+    def roles(self, roles: list) -> None:
+        """sets the value of the email property.
+
+        Raises:
+            ValueError: if supplied argument is not in the correct type.
+        """
+        min_roles_count = 1
+        if not isinstance(roles, list):
+            error_msg = "The roles agrument type must be a list"
+            self.log.error(error_msg)
+            raise ValueError(error_msg)
+        if len(roles) > self.max_attr_length and len(roles) > min_roles_count:
+            error_msg = (
+                f"The roles agrument must be greater than"
+                f" {min_roles_count} and less than "
+                f"{self.max_attr_length}"
+            )
+            self.log.error(error_msg)
+            raise ValueError(error_msg)
+        self.Roles = roles
+
+    @property
+    def read_only(self) -> bool:
+        """returns the read only flag of the base user.
+
+        Returns:
+            (bool): the read only flag.
+        """
+        return bool(self.ReadOnly)
+
+    @read_only.setter
+    def read_only(self, value: bool) -> None:
+        """sets the value of the read_only property.
+
+        Args:
+            value (bool): sets the value of the flag.
+
+        Raises:
+            ValueError: if supplied argument is not in the correct type.
+        """
+        if not isinstance(value, bool):
+            raise ValueError("The flag agrument must be of type bool")
+        self.ReadOnly = value
+
+    @property
+    def super_user(self) -> bool:
+        """returns the super user flag of the user.
+
+        Returns:
+            (bool): the super user flag.
+        """
+        return bool(self.SuperUser)
+
+    @super_user.setter
+    def super_user(self, value: bool) -> None:
+        """sets the value of the super_user property.
+
+        Args:
+            value (bool): sets the value of the flag.
+
+        Raises:
+            ValueError: if supplied argument is not in the correct type.
+        """
+        if not isinstance(value, bool):
+            raise ValueError("The flag agrument must be of type bool")
+        self.SuperUser = value
+
+    @property
+    def send_report(self) -> bool:
+        """returns the send report flag of the base user.
+
+        Returns:
+            (bool): the send report flag.
+        """
+        return bool(self.SendReport)
+
+    @send_report.setter
+    def send_report(self, value: bool) -> None:
+        """sets the value of the send_report property.
+
+        Args:
+            value (bool): sets the value of the flag.
+
+        Raises:
+            ValueError: if supplied argument is not in the correct type.
+        """
+        if not isinstance(value, bool):
+            raise ValueError("The flag agrument must be of type bool")
+        self.SendReport = value
+
+    @property
+    def last_update(self) -> float:
+        """returns the last time object was updated in UTM.
+
+        Returns:
+            (timedelta): the last time object was updated in UTM.
+        """
+        return float(self.LastUpdate)
+
+    @classmethod
+    def list_users(cls, domain_name: str) -> list:
+        """lists all the base user fora specified domain
+
+        Args:
+        domain_name (str): the name of the domain which the user belongs to.
+
+        Returns:
+            (list): containing all the BaseUser defined in the system for the\
+                requested domain.
+        """
+        users_names = []
+        for scope in scopes().list_scopes(scope=cls.__name__):
+            principal_name = str(scope["ref"])
+            user = cls.get_user_by_principal_name(principal_name)
+            if domain_name == user.domain_name:
+                users_names.append(user.account_name)
+        cls.log.debug(
+            f"current list of BaseUser records found in the " f"system: {users_names}"
+        )
+        return users_names
+
+    @classmethod
+    def is_exist(cls, domain_name: str, account_name: str):
+        """checks if an object with the specified domain and account name
+        already exists.
+
+        Args:
+            domain_name (str): the domain name of the user
+            account_name (str): the account name of the user
+
+        Returns:
+            bool: True if exists, False otherwise.
+        """
+        return account_name in cls.list_users(domain_name)
+
+    @classmethod
+    def get_user_by_principal_name(cls, principal_name: str) -> Model:
+        """returns a reference of a User, if not exist returns None
+
+        Args:
+        principal_name (str): account@domain format.
+
+
+        Returns:
+            (Model) - the user record with the corresponding account_name
+        """
+        try:
+            user = ScopesTree().from_path(principal_name, scope=cls.__name__)
+            return user
+        except KeyError:
+            msg = f"Failed to find {cls.__name__} named: {principal_name}"
+            cls.log.error(msg)
+            raise UserDoesNotExist(msg)
+
+    @classmethod
+    def get_user_by_name(cls, domain_name: str, account_name: str) -> Model:
+        """returns a reference of a User, if not exist returns None
+
+        Args:
+        domain_name (str): the name of the domain which the user belongs to.
+        account_name (str): the account name of the user.
+
+
+        Returns:
+            (Model) - the user record with the corresponding account_name
+        """
+        principal_name = create_principal_name(domain_name, account_name)
+        return cls.get_user_by_principal_name(principal_name)
+
+    def remove_role(self, role_name: str) -> None:
+        """Removes a Role from a specific object
+
+        Args:
+            role_name (str): The name of the role to remove.
+        """
+        self.log.info(f"removing role {role_name} from user {self.ref}")
+        tmp_roles = self.roles
+        tmp_roles.remove(role_name)
+        self.roles = tmp_roles
+        self.write()
+
+    @classmethod
+    def remove_role_from_all_users(cls, role_name: str) -> set:
+        """Looks for users with the specified Role, if it finds any
+        it removes the role from their attributes.
+
+        Args:
+            role_name (str): The name of the Role to remove.
+
+        Returns:
+            set: containg all the users affected by the change.
+        """
+        affected_users = set()
+        for username in cls.list_objects_names():
+            user = cls(username)
+            if role_name in user.roles:
+                user.remove_role(role_name)
+                affected_users.add(username)
+        return affected_users
+
+    @staticmethod
+    def _current_time() -> float:
+        """returns the current time in timestamp format.
+
+        Returns:
+            float: a float representing the time delta.
+        """
+        return int(datetime.now().timestamp())
+
+    @staticmethod
+    def _expiration_time(expiration_delta: int) -> float:
+        """returns a future time in timestamp format.
+
+        Args:
+            expiration_delta (int): the time delta from now.
+
+        Returns:
+            float: a float representing the time delta.
+        """
+        return int((datetime.now() + expiration_delta).timestamp())
+
+    def set_acl(self):
+        """sets the AClManager as an internal attribute."""
+        try:
+            acl_manger = NewACLManager(user=self)
+            self._acl = acl_manger.get_acl()
+        except UserPermissionsError as e:
+            self.log.debug(e)
+
+    def get_effective_permissions(self) -> dict:
+        permissions = self._acl.which_any(self.roles)
+        for resource in permissions:
+            permissions[resource] = list(permissions[resource])
+        return permissions
+
+    def has_scope_permission(self, user, permission) -> bool:
+        """
+        check if user has scope permission
+        """
+        if not user.has_permission(self.scope, f"{self.name}.{permission}"):
+            if not user.has_permission(self.scope, permission):
+                return False
+        return True
+
+    def has_permission(
+        self, resource_name: str, permission_name: str, skip_superuser: bool = False
+    ) -> bool:
+        """Check user permission to a specific resource.
+
+        Args:
+            resource_name (str): The name of the resource (capitalize as class
+                name e.g: Flow, RemoteUser...)
+            permission_name (str): the name of the permission (example: read,
+                update)
+            skip_superuser (bool, optional): waether to ignore the superuser
+                attribute or not. Defaults to False.
+
+        Returns:
+            bool: True if the user has permission, False otherwise.
+        """
+        if not skip_superuser and self.super_user:
+            return True
+
+        permission_name = permission_name.lower()
+
+        if f"{self.ref}.read".lower() == permission_name:
+            return True
+
+        try:
+            self.set_acl()
+            for role_name in self.roles:
+                if self._acl.check(role_name, resource_name, permission_name):
+                    return True
+            return False
+        except Exception as e:
+            self.log.debug(e)
+            return False

--- a/dal/models/container.py
+++ b/dal/models/container.py
@@ -7,7 +7,7 @@
    - Manuel Silva  (manuel.silva@mov.ai) - 2020
 """
 
-from dal.scopes.scopestree import ScopeObjectNode, ScopeNode, scopes
+from .scopestree import ScopeObjectNode, ScopeNode, scopes
 
 
 class Container(ScopeObjectNode):

--- a/dal/models/flow.py
+++ b/dal/models/flow.py
@@ -7,13 +7,14 @@
    - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
    - Manuel Silva  (manuel.silva@mov.ai) - 2020
 """
-
 from types import SimpleNamespace
-from movai_core_shared.logger import Log
-from .scopestree import scopes
-from dal.helpers import GFlow
-from dal.helpers.parsers import ParamParser
 from movai_core_shared.consts import (ROS1_NODELETSERVER)
+from movai_core_shared.logger import Log
+
+from .flowlinks import FlowLinks
+from .scopestree import scopes
+from dal.helpers.flow import GFlow
+from dal.helpers.parsers import ParamParser
 from .model import Model
 
 

--- a/dal/models/flowlinks.py
+++ b/dal/models/flowlinks.py
@@ -8,7 +8,7 @@
 """
 import re
 import uuid
-from dal.scopes.scopestree import ScopePropertyNode, ScopeNode
+from .scopestree import ScopePropertyNode, ScopeNode
 from dal.validation import Template
 
 

--- a/dal/models/graphicscenevalue.py
+++ b/dal/models/graphicscenevalue.py
@@ -8,7 +8,7 @@
 """
 from geometry_msgs.msg import Pose  # pylint: disable=import-error
 
-from dal.scopes.scopestree import ScopeNode, ScopePropertyNode
+from dal.models.scopestree import ScopeNode, ScopePropertyNode
 
 
 class GraphicSceneValue(ScopePropertyNode):

--- a/dal/models/internaluser.py
+++ b/dal/models/internaluser.py
@@ -1,0 +1,262 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Erez Zomer  (erez@mov.ai) - 2022
+"""
+from movai_core_shared.core.securepassword import SecurePassword
+from movai_core_shared.envvars import DEFAULT_ROLE_NAME
+from movai_core_shared.consts import INTERNAL_DOMAIN
+from movai_core_shared.exceptions import PasswordError, PasswordComplexityError
+
+from dal.models.model import Model
+from dal.models.baseuser import BaseUser
+from dal.models.user import User
+
+
+class InternalUser(BaseUser):
+    """This class represents the internal user object as record in the DB."""
+
+    secure = SecurePassword()
+    min_password_length = 8
+
+    @classmethod
+    def create(
+        cls,
+        account_name: str,
+        password: str,
+        roles: list,
+        common_name: str = "",
+        email: str = "",
+        super_user: bool = False,
+        read_only: bool = False,
+        send_report: bool = False,
+    ) -> BaseUser:
+        """Creates a new internal user
+
+        args:
+            account_name (str): the name of the user to create
+                (can not be empty).
+            password (str): the password for the corresponding user
+                (can not be empty).
+
+        returns:
+            obj (User): the user object created.
+        """
+        if password == "":
+            error_msg = "password is invalid"
+            cls.log.error(error_msg)
+            raise ValueError(error_msg)
+
+        user = super().create(
+            domain_name=INTERNAL_DOMAIN,
+            account_name=account_name,
+            common_name=common_name,
+            user_type="INTERNAL",
+            roles=roles,
+            email=email,
+            super_user=super_user,
+            read_only=read_only,
+            send_report=send_report,
+        )
+        try:
+            user._validate_password_complexity(password)
+            user.hash_password(password)
+            user.write()
+            return user
+        except PasswordError as error:
+            user.delete()
+            raise error
+
+    @classmethod
+    def convert_user(cls, old_user: User) -> Model:
+        """This function convert users from the old User type to the new
+        InternalUser format.
+
+        Args:
+            old_user (User): The user to convert
+
+        Returns:
+            Model: The newly created user.
+        """
+        new_user_email = str(old_user.Email or "")
+        new_user_role = str(old_user.Role or DEFAULT_ROLE_NAME)
+        new_user = super().create(
+            domain_name=INTERNAL_DOMAIN,
+            account_name=old_user.ref,
+            common_name=old_user.ref,
+            user_type="INTERNAL",
+            roles=[new_user_role],
+            email=new_user_email,
+            super_user=bool(old_user.Superuser),
+            read_only=False,
+            send_report=bool(old_user.SendReport),
+        )
+        new_user.Password = old_user.Password
+        new_user.write()
+
+    @classmethod
+    def remove(cls, account_name: str) -> None:
+        """removes an BaseUser record from DB
+
+        Args:
+        domain_name (str): the name of the domain which the user belongs to.
+        account_name (str): the account name of the user to remove.
+        """
+        super().remove(INTERNAL_DOMAIN, account_name)
+
+    @property
+    def password(self) -> bytes:
+        """returns the value of the password attribute."""
+        return self.Password
+
+    @password.setter
+    def password(self, secret: str) -> None:
+        """sets the value of the password attribute."""
+        self.Password = secret
+
+    def hash_password(self, password: str) -> None:
+        """This function uses sha256 algorithm to store a password in
+        a secured way.
+
+        Args:
+            password (str): the password to hash.
+
+        Returns:
+            str: the hash of the password
+        """
+        self.password = self.secure.create_salted_hash(password)
+
+    def _validate_password_has_changed(
+        self, current_password: str, new_password: str
+    ) -> None:
+        """validates that both passwords match
+
+        Args:
+            new_password (str): the new password to set.
+            confirm_password (str): confirmation of the password.
+
+        Raises:
+            PasswordError: if the password do not match.
+        """
+        if current_password == new_password:
+            error_msg = "new password must not match current password"
+            raise PasswordError(error_msg)
+
+    def _validate_confirmation_password(
+        self, new_password: str, confirm_password: str
+    ) -> None:
+        """validates that both passwords match
+
+        Args:
+            new_password (str): the new password to set.
+            confirm_password (str): confirmation of the password.
+
+        Raises:
+            PasswordError: if the password do not match.
+        """
+        if new_password != confirm_password:
+            error_msg = "Confirmation password doesn't match new password"
+            raise PasswordError(error_msg)
+
+    def _validate_password_complexity(self, password: str) -> None:
+        """checks the password against complexity settings.
+
+        Args:
+            password (str): the password to check.
+
+        Raises:
+            PasswordComplexityError: _if password has failed complexity check.
+        """
+        if len(password) < self.min_password_length:
+            error_msg = "Password must be at least 8 characters long."
+            raise PasswordComplexityError(error_msg)
+
+    def verify_password(self, password: str) -> bool:
+        """Verify a password against an hash
+
+        Args:
+            password (str): the password of the user.
+
+        Raises:
+            ValueError: if Password attribute is not defined on the user
+                object.
+
+        Returns:
+            bool: True if password validation succeeds, False otherwise.
+        """
+        if not isinstance(password, str):
+            error_msg = "password must be a string"
+            self.log.error(error_msg)
+            raise ValueError(error_msg)
+
+        if not self.Password:
+            error_msg = "failed to verify password"
+            raise PasswordError(error_msg)
+
+        return self.secure.verify_password(password, self.Password)
+
+    def reset_password(self, new_password: str, confirm_password: str) -> None:
+        """Resets a user password without requiring current password.
+
+        Args:
+        new_password (str): the new password to set for the user.
+        confirm_password (str): confirm new password.
+
+        Exceptions:
+        ValueError - if supplied password aren't of the correct type (string).
+        PasswordError - if new password and confirmed password do not match.
+        PasswordComplexityError - if new password does not comply complexity
+            requirements.
+
+        Returns:
+            (bool): True if password reset succeeded.
+        """
+        if not isinstance(new_password, str) and not isinstance(confirm_password, str):
+            error_msg = "password must be a string"
+            self.log.error(error_msg)
+            raise ValueError(error_msg)
+        self._validate_confirmation_password(new_password, confirm_password)
+        self._validate_password_complexity(new_password)
+        self.hash_password(new_password)
+        self.write()
+
+    def change_password(
+        self, current_password: str, new_password: str, confirm_password: str
+    ) -> None:
+        """Changes a user password
+
+        Args:
+        current_password (str): old password.
+        new_password (str): new password.
+        confirm_password (str): confirm password.
+
+        Exceptions:
+        ValueError - if supplied password aren't in the correct type (string).
+        PasswordError - if current password could not be verified.
+        PasswordError - if new password and confirmed password do not match.
+        PasswordComplexityError - if new password does not comply complexity
+            requirements.
+
+        Returns:
+            (bool): True if password reset succeeded.
+        """
+        if not isinstance(current_password, str):
+            error_msg = "password must be a string"
+            self.log.error(error_msg)
+            raise ValueError(error_msg)
+
+        if not self.verify_password(current_password):
+            error_msg = (
+                "Current password validation failed. " "Could not change user password"
+            )
+            self.log.error(error_msg)
+            raise PasswordError(error_msg)
+
+        self._validate_password_has_changed(current_password, new_password)
+        self.reset_password(new_password, confirm_password)
+
+
+Model.register_model_class("InternalUser", InternalUser)

--- a/dal/models/ldapconfig.py
+++ b/dal/models/ldapconfig.py
@@ -7,7 +7,7 @@ from movai_core_shared.exceptions import (
     LdapConfigMissingParameter)
 
 from dal.models.model import Model
-from dal.scopes.scopestree import ScopesTree, scopes
+from dal.models.scopestree import ScopesTree, scopes
 
 
 

--- a/dal/models/node.py
+++ b/dal/models/node.py
@@ -17,6 +17,7 @@ class Node(Model):
     """
     Provides the default configuration to launch a GD_Node
     """
+
     __RELATIONS__ = {
         # "schemas/1.0/Node/PortsInst/Template": {
         #     "schema_version": "1.0",
@@ -30,7 +31,7 @@ class Node(Model):
 
     @property
     def is_remappable(self) -> bool:
-        """ Returns True if the ports are allowed to remap """
+        """Returns True if the ports are allowed to remap"""
         # get the value from the attribute Remappable
         # possible values True, False, None, ""
         prop = True if self.Remappable in [None, ""] else self.Remappable
@@ -46,7 +47,7 @@ class Node(Model):
 
     @property
     def is_node_to_launch(self) -> bool:
-        """ Returns True if it should be launched """
+        """Returns True if it should be launched"""
         # get the value from the attribute Launch
         # possible values True, False, None, ""
         prop = True if self.Launch in [None, ""] else self.Launch
@@ -62,7 +63,7 @@ class Node(Model):
 
     @property
     def is_persistent(self) -> bool:
-        """ Returns True if it persists on state transitions """
+        """Returns True if it persists on state transitions"""
         # get the value from the attribute Persistent
         # possible values True, False, None, ""
         prop = False if self.Persistent in [None, ""] else self.Persistent
@@ -78,30 +79,30 @@ class Node(Model):
 
     @property
     def is_nodelet(self) -> bool:
-        """ Returns True if the node is of type Nodelet """
+        """Returns True if the node is of type Nodelet"""
         return self.Type == ROS1_NODELET
 
     @property
     def is_state(self) -> bool:
-        """ Returns True if the node is of type State """
+        """Returns True if the node is of type State"""
         return self.Type == MOVAI_STATE
 
     @property
     def is_plugin(self) -> bool:
-        """ Returns True if the node is of type plugin """
+        """Returns True if the node is of type plugin"""
         return self.Type == ROS1_PLUGIN
 
     def get_params(self) -> dict:
-        '''
+        """
         Return a dict with all parameters in the format <parameter name>: <Parameter.Value>
         (Parameter format is {key:{Value: <value>, Description: <value>}})
-        '''
+        """
         params = self.Parameter.serialize()
         output = {key: value["Value"] for key, value in params.items()}
         return output
 
     def get_port(self, port_inst: str):
-        """ Returns an instance (Ports) of the port instance template """
+        """Returns an instance (Ports) of the port instance template"""
 
         tpl = self.PortsInst[port_inst].Template
 

--- a/dal/models/nodeinst.py
+++ b/dal/models/nodeinst.py
@@ -7,7 +7,7 @@
    - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
    - Manuel Sila  (manuel.silva@mov.ai) - 2020
 """
-from dal.scopes.scopestree import ScopeObjectNode, ScopeNode, scopes
+from .scopestree import ScopeObjectNode, ScopeNode, scopes
 from movai_core_shared.logger import Log
 
 

--- a/dal/models/packagefile.py
+++ b/dal/models/packagefile.py
@@ -11,7 +11,7 @@
 
 import hashlib
 
-from dal.scopes.scopestree import (
+from dal.models.scopestree import (
     ScopeObjectNode,
     ScopePropertyNode,
     ScopeNode,

--- a/dal/models/remoteuser.py
+++ b/dal/models/remoteuser.py
@@ -1,0 +1,19 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Erez Zomer  (erez@mov.ai) - 2022
+"""
+from dal.models.model import Model
+from dal.models.baseuser import BaseUser
+
+
+class RemoteUser(BaseUser):
+    """This class represents the remote user object as record in the DB."""
+
+    pass
+
+
+Model.register_model_class("RemoteUser", RemoteUser)

--- a/dal/models/role.py
+++ b/dal/models/role.py
@@ -1,0 +1,97 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Tiago Teixeira  (tiago.teixeira@mov.ai) - 2020
+
+   Role Model (only of name)
+"""
+from typing import Dict
+
+from movai_core_shared.exceptions import RoleAlreadyExist, RoleDoesNotExist
+from movai_core_shared.envvars import DEFAULT_ROLE_NAME
+
+from dal.models.scopestree import scopes
+from dal.models.model import Model
+from dal.models.aclobject import AclObject
+from dal.models.remoteuser import RemoteUser
+from dal.models.internaluser import InternalUser
+from dal.models.acl import NewACLManager
+
+
+class Role(Model):
+    """Role Model (only of name)"""
+
+    @classmethod
+    def create(cls, name: str, resources: Dict) -> None:
+        """create a new Role object in DB
+
+        Args:
+            name (str): The name of the Role
+            resources (Dict): resources permissions map
+
+        Raises:
+            RoleAlreadyExist: in case a Role with that name already exist.
+        """
+        try:
+            role = scopes().create(Role.__name__, name)
+            role.Label = name
+            role.update(resources)
+            return role
+        except ValueError:
+            error_msg = "The requested Role already exist"
+            cls.log.error(error_msg)
+            raise RoleAlreadyExist(error_msg)
+
+    @classmethod
+    def create_default_role(cls):
+        if not Role.is_exist(DEFAULT_ROLE_NAME):
+            resources = NewACLManager.get_permissions()
+            default_role = cls.create(DEFAULT_ROLE_NAME, resources)
+        else:
+            default_role = Role(DEFAULT_ROLE_NAME)
+        return default_role
+
+    def update(self, resources: Dict) -> None:
+        """Update role data"""
+        self.Resources = resources
+        self.write()
+
+    @classmethod
+    def remove(cls, name: str) -> None:
+        """Removes a Role from DB.
+
+        Args:
+            name (str): The name of the Role to remove
+
+        Raises:
+            RoleDoesNotExist: In case there is no Role with that name.
+        """
+        try:
+            RemoteUser.remove_role_from_all_users(name)
+            InternalUser.remove_role_from_all_users(name)
+            AclObject.remove_roles_from_all_objects(name)
+            role = Role(name)
+            scopes().delete(role)
+        except KeyError:
+            error_msg = "The requested Role does not exist"
+            cls.log.error(error_msg)
+            raise RoleDoesNotExist(error_msg)
+
+    @staticmethod
+    def list_roles_names() -> list:
+        """Retunns a list with all Roles exist in the system.
+
+        Returns:
+            list: containing the name of the current Roles.
+        """
+        roles_names = []
+        for obj in scopes().list_scopes(scope="Role"):
+            role_name = str(obj["ref"])
+            roles_names.append(role_name)
+        return roles_names
+
+
+Model.register_model_class("Role", Role)

--- a/dal/models/user.py
+++ b/dal/models/user.py
@@ -1,0 +1,382 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Dor Marcous  (Dor@mov.ai) - 2021
+
+   User Model
+"""
+
+import hashlib
+import os
+import binascii
+from typing import List, Dict, Union
+from datetime import datetime
+import jwt
+
+from movai_core_shared.exceptions import UserDoesNotExist
+
+from dal.models.scopestree import ScopesTree, scopes
+from dal.models.model import Model
+from dal.models.acl import ACLManager
+
+from dal.data.shared.vault import (
+    JWT_ACCESS_EXPIRATION_DELTA,
+    JWT_REFRESH_EXPIRATION_DELTA,
+    JWT_SECRET_KEY,
+)
+
+
+class User(Model):
+    """This class represents the user object as record in the DB,
+    it handles all operations required for user: authentication,
+    token generation and so..
+    """
+
+    def __delattr__(self, key):
+        # user class disables deleting a feature
+        # implemented because of abstract methods
+        raise NotImplementedError
+
+    def __setitem__(self, key, value):
+        self.__dict__[key] = value
+
+    @property
+    def role(self) -> Union[Model, None]:
+        """This funtion returns the corresponding role of the user.
+
+        Returns:
+            Union[Model, None]: a Role object or None if it not found.
+        """
+        try:
+            return scopes.from_path(self.Role, scope="Role")
+        except KeyError:
+            return None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._acl = None
+
+    def set_acl(self):
+        """sets the AClManager as an internal attribute."""
+        try:
+            acl_manger = ACLManager(user=self)
+            self._acl = acl_manger.get_acl()
+        except Exception as e:
+            self.log.debug(e)
+
+    @staticmethod
+    def hash_password(password: str) -> str:
+        """This function uses sha256 algorithm to store a
+        password secured.
+
+        Args:
+            password (str): the password to hash.
+
+        Returns:
+            str: the hash of the password
+        """
+        salt = hashlib.sha256(os.urandom(60)).hexdigest().encode("ascii")
+        pwdhash = binascii.hexlify(
+            hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 100000)
+        )
+        return (salt + pwdhash).decode("ascii")
+
+    def verify_password(self, password: str) -> bool:
+        """Verify a password against an hash
+
+        Args:
+            password (str): the password of the user.
+
+        Raises:
+            ValueError: if Password attribute is not defined on the user
+                object.
+
+        Returns:
+            bool: True if password validation succeeds, False otherwise.
+        """
+
+        if not self.Password:
+            error_msg = "failed to verify password"
+            raise ValueError(error_msg)
+
+        salt = self.Password[:64].encode("utf-8")
+        hashed = self.Password[64:].encode("utf-8")
+        test_hash = binascii.hexlify(
+            hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 100000)
+        )
+        return hashed == test_hash
+
+    def get_permission(self, resource_name: str) -> List:
+        """This function returns a list of resource permissions for a the user.
+
+        Args:
+            resource_name (str): the name of the resource which permissions
+                are requested.
+
+        Returns:
+            List: a list of a given permission for this resource.
+        """
+        try:
+            return list(
+                self._acl.which_permissions_all([self.Role], resource_name.capitalize())
+            )
+        except Exception as e:
+            self.log.debug(e)
+            return list()
+
+    def has_scope_permission(self, user, permission) -> bool:
+        """
+        check if user has scope permission
+        """
+        if not user.has_permission(
+            self.scope,
+            "{prefix}.{permission}".format(prefix=self.name, permission=permission),
+        ):
+            if not user.has_permission(self.scope, permission):
+                return False
+        return True
+
+    def has_permission(
+        self, resource_name: str, permission_name: str, skip_superuser: bool = False
+    ) -> bool:
+        """Check if user has permission"""
+        if not skip_superuser and self.Superuser:
+            return True
+
+        res_name = resource_name.capitalize()
+        perm_name = permission_name.lower()
+
+        if f"{self.ref}.read".lower() == permission_name:
+            return True
+
+        try:
+            if self._acl is None:
+                self.set_acl()
+            return self._acl.check(self.Role, res_name, perm_name)
+        except Exception as e:
+            self.log.debug(e)
+            return False
+
+    def user_permissions(self) -> Dict:
+        """Get dict of the user permissions"""
+
+        role = self.Role
+        all_roles = ACLManager.get_roles()
+        all_resources_permissions = ACLManager.get_permissions()
+
+        resources_parsed_data = {}
+        for resource, permissions in all_resources_permissions.items():
+
+            has_role_resource = False
+            if resource in all_roles.get(role, {}).get("Resources", {}):
+                has_role_resource = all_roles[role]["Resources"][resource]
+
+            user_permissions = []
+            for perm in permissions:
+
+                role_perm_value = has_role_resource and (perm in has_role_resource)
+
+                perm_value = self.has_permission(
+                    resource_name=resource, permission_name=perm, skip_superuser=True
+                )
+
+                perm_dict = {"permission": perm, "value": perm_value}
+
+                if has_role_resource:
+                    perm_dict["inherited"] = role_perm_value
+
+                user_permissions.append(perm_dict)
+
+            resources_parsed_data[resource] = user_permissions
+
+        return resources_parsed_data
+
+    def create_id(self):
+        """Create hash id for user"""
+        fields = {  # set()
+            "APIPermission",
+            "Layout",
+            "name",
+            "Type",
+            "Version",
+            "WidgetPermission",
+            "Application",
+            "Applications",
+        }
+
+        user_dict = self.serialize()
+        user_dict["name"] = self.ref
+        to_delete = set.difference(fields, set(user_dict))
+
+        for key in to_delete:
+            if key in user_dict.keys():
+                del user_dict[key]
+
+        return user_dict
+
+    def _token_gen(self, token_type: str):
+        """Generate or refresh authentication token"""
+        time_expiration = (
+            JWT_ACCESS_EXPIRATION_DELTA
+            if token_type == "token"
+            else JWT_REFRESH_EXPIRATION_DELTA
+        )
+        message = {
+            "sub": token_type,
+            "iat": int(datetime.now().timestamp()),
+            "exp": int((datetime.now() + time_expiration).timestamp()),
+            "username": self.ref,
+            "message": self.create_id(),
+        }
+
+        token = jwt.encode(message, JWT_SECRET_KEY).decode("utf-8")
+        return token
+
+    def get_token(self):
+        """Generate authentication token"""
+
+        return self._token_gen("token")
+
+    def get_refresh_token(self):
+        """Generate refresh token"""
+
+        return self._token_gen("refresh")
+
+    @classmethod
+    def verify_token(cls, token):
+        """This function validates that the token sent by client us valid for
+        the corresponding user.
+
+        Args:
+            token ([type]): the token to verify
+
+        Raises:
+            ValueError: if token has expired
+            ValueError: if decoding has failed.
+            ValueError: if the token is invalid.
+
+        Returns:
+            [type]: the token data after being decoded.
+        """
+
+        try:
+            token_data = jwt.decode(token, JWT_SECRET_KEY, "RS256")
+            # ToDo check token data against other stuff.. user still exists, is active etc..
+        except jwt.ExpiredSignatureError as e:
+            raise ValueError("Signature expired.") from e
+        except jwt.DecodeError as e:
+            raise ValueError("JWT Error: Token could not be decoded.") from e
+        except jwt.InvalidTokenError as e:
+            raise ValueError("Invalid token.") from e
+
+        return token_data
+
+    @classmethod
+    def create(cls, username: str, password: str) -> Model:
+        """Creates a new user
+
+        args:
+            username (str): the name of the user to create (can not be empty)
+            password (str): the password for the corresponding user
+                (can not be empty).
+
+        returns:
+            obj (User): the user object created.
+        """
+        if not isinstance(username, str) or not isinstance(password, str):
+            error_msg = "credentials are in unknown format"
+            cls.log.error(error_msg)
+            raise ValueError(error_msg)
+        if username == "":
+            error_msg = "username is invalid"
+            cls.log.error(error_msg)
+            raise ValueError(error_msg)
+        if username == "":
+            error_msg = "password is invalid"
+            cls.log.error(error_msg)
+            raise ValueError(error_msg)
+
+        obj = scopes().create("User", username)
+        obj.Password = obj.hash_password(password)
+        obj.write()
+
+        return obj
+
+    @classmethod
+    def reset(
+        cls,
+        username: str,
+        pw_current: str,
+        pw_new: str,
+        pw_newc: str,
+        validate: bool = True,
+    ) -> bool:
+        """Resets a user password
+
+        Args:
+        pw_current (str): old password.
+        pw_new (str): new password.
+        pw_newc (str): confirm password.
+        validate (bool): confirm current password before setting the
+            new password.
+
+        Exceptions:
+        ValueError - if new password and confirmed password do not mathc.
+        ValueError - if new password is an empty string.
+        ValueError - if user does not exist.
+
+        Returns:
+            (bool): True if password reset succeeded, False otherwise.
+        """
+
+        if pw_new != pw_newc:
+            error_msg = "Confirmation password doesn't match"
+            cls.log.error(error_msg)
+            raise ValueError(error_msg)
+
+        if pw_new == "":
+            error_msg = "New password is not valid"
+            cls.log.error(error_msg)
+            raise ValueError(error_msg)
+
+        try:
+            user = scopes().User[username]
+        except KeyError as e:
+            error_msg = f"user: {username} not exist, password reset failed"
+            cls.log.error(error_msg)
+            raise ValueError(error_msg) from e
+
+        if validate and not user.verify_password(pw_current):
+            error_msg = "Current password validation failed, Could not update"
+            " user password"
+            cls.log.error(error_msg)
+            raise ValueError(error_msg)
+
+        user.Password = user.hash_password(pw_new)
+        user.write()
+
+        return True
+
+    @classmethod
+    def get_user_by_name(cls, username: str) -> Model:
+        """returns a reference of a User, if not exist returns None
+
+        Args:
+        username - the name of the User to get a reference for
+
+        Returns:
+            (User) - the user record with the corresponding username
+        """
+        try:
+            user = ScopesTree().from_path(username, scope="User")
+            return user
+        except KeyError:
+            error_msg = f"user {username} does not exist"
+            cls.log.error(error_msg)
+            raise UserDoesNotExist(error_msg)
+
+
+Model.register_model_class("User", User)

--- a/dal/plugins/persistence/filesystem/filesystem.py
+++ b/dal/plugins/persistence/filesystem/filesystem.py
@@ -28,8 +28,7 @@ from dal.data import (schemas,
 from dal.models.scopestree import ScopeInstanceVersionNode, ScopesTree
 from dal.models.model import Model
 from dal.backup import RestoreManager
-
-from movai.remote import RemoteArchive
+from dal.data.archive import RemoteArchive
 
 
 

--- a/dal/plugins/resource.py
+++ b/dal/plugins/resource.py
@@ -8,7 +8,7 @@
 """
 from abc import abstractmethod
 from urllib.parse import urlparse
-from .plugin import Plugin, PluginManager
+from dal.plugins.plugin import Plugin, PluginManager
 
 
 class ResourceException(Exception):

--- a/dal/scopes/application.py
+++ b/dal/scopes/application.py
@@ -14,9 +14,10 @@ class Application(Scope):
     """Application model"""
 
     scope = "Application"
-    
-    permissions = [*Scope.permissions, 'execute']
 
-    def __init__(self, name, version='latest', new=False, db='global'):
-        super().__init__(scope="Application", name=name, version=version, new=new, db=db)
+    permissions = [*Scope.permissions, "execute"]
 
+    def __init__(self, name, version="latest", new=False, db="global"):
+        super().__init__(
+            scope="Application", name=name, version=version, new=new, db=db
+        )

--- a/dal/scopes/message.py
+++ b/dal/scopes/message.py
@@ -17,8 +17,11 @@ import sys
 import rospkg
 import genmsg
 import rosmsg
+
 from dal.scopes.scope import Scope
 from dal.movaidb import MovaiDB
+
+
 
 sys.stderr = open(os.devnull, "w")  # just to ignore stupid print
 sys.stderr = sys.__stderr__
@@ -27,9 +30,9 @@ sys.stderr = sys.__stderr__
 class Message(Scope):
     """Message class"""
 
-    scope = 'Message'
+    scope = "Message"
 
-    def __init__(self, name, version='latest', new=False, db='global'):
+    def __init__(self, name, version="latest", new=False, db="global"):
         super().__init__(scope="Message", name=name, version=version, new=new, db=db)
 
     def is_valid(self):
@@ -37,44 +40,42 @@ class Message(Scope):
         return True
 
     @classmethod
-    def get_packages(cls, msg_type='all', db='global') -> list:
+    def get_packages(cls, msg_type="all", db="global") -> list:
         """Gives a list of all packages containing messages of a type"""
 
-        if msg_type not in ['all', 'msg', 'srv', 'action']:
+        if msg_type not in ["all", "msg", "srv", "action"]:
             raise Exception(
-                'Invalid message type. Valid ones are: "msg", "srv", "action" and "all"')
+                'Invalid message type. Valid ones are: "msg", "srv", "action" and "all"'
+            )
 
         rospack = rospkg.RosPack()
 
         msg_packs = []
         srv_packs = []
         action_packs = []
-        action_names = ['ActionFeedback', 'ActionGoal', 'ActionResult']
+        action_names = ["ActionFeedback", "ActionGoal", "ActionResult"]
 
-        db_packs = [x for x in MovaiDB(db).search_by_args(
-            cls.scope, Name='*')[0][cls.scope]]
+        db_packs = [
+            x for x in MovaiDB(db).search_by_args(cls.scope, Name="*")[0][cls.scope]
+        ]
 
-        if msg_type in ('msg', 'all'):
-            msg_packs = [
-                x for x, _ in rosmsg.iterate_packages(rospack, '.msg')]
+        if msg_type in ("msg", "all"):
+            msg_packs = [x for x, _ in rosmsg.iterate_packages(rospack, ".msg")]
             for package in db_packs:
                 if [key for key in Message(package).Msg]:
                     msg_packs.append(package)
 
-        if msg_type in ('srv', 'all'):
-            srv_packs = [
-                x for x, _ in rosmsg.iterate_packages(rospack, '.srv')]
+        if msg_type in ("srv", "all"):
+            srv_packs = [x for x, _ in rosmsg.iterate_packages(rospack, ".srv")]
             for package in db_packs:
                 if [key for key in Message(package).Srv]:
                     srv_packs.append(package)
 
-        if msg_type == 'action':
-            temp_msg_packs = [
-                x for x in rosmsg.iterate_packages(rospack, '.msg')]
+        if msg_type == "action":
+            temp_msg_packs = [x for x in rosmsg.iterate_packages(rospack, ".msg")]
 
             for (package, direc) in temp_msg_packs:
-                temp_list = [msg for msg in rosmsg._list_types(
-                    direc, 'msg', '.msg')]
+                temp_list = [msg for msg in rosmsg._list_types(direc, "msg", ".msg")]
 
                 for msg in action_names:
                     if not any(msg in elem for elem in temp_list):
@@ -89,12 +90,13 @@ class Message(Scope):
         return list(set(msg_packs + srv_packs + action_packs))
 
     @classmethod
-    def get_msgs(cls, package: str, msg_type='all', db='global') -> list:
+    def get_msgs(cls, package: str, msg_type="all", db="global") -> list:
         """Gives a list of all messages of some type in a package"""
 
-        if msg_type not in ['all', 'msg', 'srv', 'action']:
+        if msg_type not in ["all", "msg", "srv", "action"]:
             raise Exception(
-                'Invalid message type. Valid ones are: "msg", "srv", "action" and "all"')
+                'Invalid message type. Valid ones are: "msg", "srv", "action" and "all"'
+            )
 
         rospack = rospkg.RosPack()
 
@@ -102,40 +104,38 @@ class Message(Scope):
         srv_list = []
         action_list = []
 
-        if msg_type in ('msg', 'all'):
+        if msg_type in ("msg", "all"):
             try:  # check in ROS packages
                 # path = os.path.join(rospack.get_path(package), 'msg') #gets msgs, not actions in custom pkgs
-                #msg_list = rosmsg._list_types(path, 'msg', '.msg')
+                # msg_list = rosmsg._list_types(path, 'msg', '.msg')
                 path = rosmsg._get_package_paths(package, rospack)
                 for p in path:
-                    msg_list.extend(rosmsg._list_types(
-                        p+'/msg', 'msg', '.msg'))
+                    msg_list.extend(rosmsg._list_types(p + "/msg", "msg", ".msg"))
             except:  # check in DB packages
                 try:
                     msg_list = [key for key in Message(package).Msg]
                 except:
                     print('Package "%s" is non existent' % package)
 
-        if msg_type in ('srv', 'all'):
+        if msg_type in ("srv", "all"):
             try:  # check in ROS packages
-                path = os.path.join(rospack.get_path(package), 'srv')
-                srv_list = rosmsg._list_types(path, 'srv', '.srv')
+                path = os.path.join(rospack.get_path(package), "srv")
+                srv_list = rosmsg._list_types(path, "srv", ".srv")
             except:  # check in DB packages
                 try:
                     srv_list = [key for key in Message(package).Srv]
                 except:
                     print('Package "%s" is non existent' % package)
 
-        if msg_type == 'action':
+        if msg_type == "action":
             try:  # check in ROS packages
                 path = rosmsg._get_package_paths(package, rospack)
                 temp_msg_list = []
                 for p in path:
-                    temp_msg_list.extend(
-                        rosmsg._list_types(p+'/msg', 'msg', '.msg'))
+                    temp_msg_list.extend(rosmsg._list_types(p + "/msg", "msg", ".msg"))
 
                 for message in temp_msg_list:
-                    if message[-6:] == 'Action':
+                    if message[-6:] == "Action":
                         action_list.append(message)
             except:  # check in DB packages
                 try:
@@ -146,24 +146,27 @@ class Message(Scope):
         return list(set(msg_list + srv_list + action_list))
 
     @classmethod
-    def get_all(cls, db='global') -> dict:
+    def get_all(cls, db="global") -> dict:
         """Gives the all available messages of all types organized by package"""
         rospack = rospkg.RosPack()
 
         full_dict = {}
 
-        msg_packs = [x for x in rosmsg.iterate_packages(rospack, '.msg')]
-        srv_packs = [x for x in rosmsg.iterate_packages(rospack, '.srv')]
-        db_packs = [x for x in MovaiDB(db).search_by_args(
-            cls.scope, Name='*')[0][cls.scope]]
+        msg_packs = [x for x in rosmsg.iterate_packages(rospack, ".msg")]
+        srv_packs = [x for x in rosmsg.iterate_packages(rospack, ".srv")]
+        db_packs = [
+            x for x in MovaiDB(db).search_by_args(cls.scope, Name="*")[0][cls.scope]
+        ]
 
         for (package, direc) in msg_packs:
             full_dict[package] = [
-                msg for msg in rosmsg._list_types(direc, 'msg', '.msg')]
+                msg for msg in rosmsg._list_types(direc, "msg", ".msg")
+            ]
 
         for (package, direc) in srv_packs:
-            full_dict[package] = full_dict.get(
-                package, []) + [srv for srv in rosmsg._list_types(direc, 'srv', '.srv')]
+            full_dict[package] = full_dict.get(package, []) + [
+                srv for srv in rosmsg._list_types(direc, "srv", ".srv")
+            ]
 
         for package in db_packs:
             msgs = [key for key in Message(package).Msg]
@@ -174,70 +177,72 @@ class Message(Scope):
         return full_dict
 
     @classmethod
-    def export_portdata(cls, db='global') -> dict:
+    def export_portdata(cls, db="global") -> dict:
         """Gives all messages/services available organized by type. Possibly intended to replace get_all(), but kept for legacy reasons"""
 
         rospack = rospkg.RosPack()
 
-        root = {
-            "ROS1_msg": {},
-            "ROS1_srv": {},
-            "ROS1_action": {}
-        }
+        root = {"ROS1_msg": {}, "ROS1_srv": {}, "ROS1_action": {}}
 
         # get the messages
-        msg_packs = [x for x in rosmsg.iterate_packages(rospack, '.msg')]
+        msg_packs = [x for x in rosmsg.iterate_packages(rospack, ".msg")]
 
         for (pkg, path) in msg_packs:
             # possibly...
-            if pkg == 'actionlib':
+            if pkg == "actionlib":
                 # don't put this as a 'message'
                 continue
 
-            root['ROS1_msg'][pkg] = root['ROS1_msg'].get(
-                pkg, []) + [msg for msg in rosmsg._list_types(path, 'msg', '.msg')]
+            root["ROS1_msg"][pkg] = root["ROS1_msg"].get(pkg, []) + [
+                msg for msg in rosmsg._list_types(path, "msg", ".msg")
+            ]
 
         # save some memory
         del msg_packs
 
         # now the services
-        srv_packs = [x for x in rosmsg.iterate_packages(rospack, '.srv')]
+        srv_packs = [x for x in rosmsg.iterate_packages(rospack, ".srv")]
 
         for (pkg, path) in srv_packs:
-            root['ROS1_srv'][pkg] = root['ROS1_srv'].get(
-                pkg, []) + [srv for srv in rosmsg._list_types(path, 'srv', '.srv')]
+            root["ROS1_srv"][pkg] = root["ROS1_srv"].get(pkg, []) + [
+                srv for srv in rosmsg._list_types(path, "srv", ".srv")
+            ]
 
         # memory
         del srv_packs
 
         # now ... actions
-        db_packs = [x for x in MovaiDB(db).search_by_args(
-            cls.scope, Name="*")[0][cls.scope]]
+        db_packs = [
+            x for x in MovaiDB(db).search_by_args(cls.scope, Name="*")[0][cls.scope]
+        ]
         for pkg in db_packs:
             # so ... all or just actions ?
             mm = Message(pkg)
             if len(mm.Msg):
-                root['ROS1_msg'][pkg] = root['ROS1_msg'].get(
-                    pkg, []) + [k for k in mm.Msg]
+                root["ROS1_msg"][pkg] = root["ROS1_msg"].get(pkg, []) + [
+                    k for k in mm.Msg
+                ]
             if len(mm.Srv):
-                root['ROS1_srv'][pkg] = root['ROS1_srv'].get(
-                    pkg, []) + [k for k in mm.Srv]
+                root["ROS1_srv"][pkg] = root["ROS1_srv"].get(pkg, []) + [
+                    k for k in mm.Srv
+                ]
             if len(mm.Action):
-                root['ROS1_action'][pkg] = root['ROS1_action'].get(
-                    pkg, []) + [k for k in mm.Action]
+                root["ROS1_action"][pkg] = root["ROS1_action"].get(pkg, []) + [
+                    k for k in mm.Action
+                ]
 
         del db_packs
 
         # we actually need to parse actions from the messages?
-        for pkg in root['ROS1_msg']:
-            pkg_msgs = root['ROS1_msg'][pkg]
+        for pkg in root["ROS1_msg"]:
+            pkg_msgs = root["ROS1_msg"][pkg]
             # check for any message with '*ActionGoal'
             loop = True
             while loop:
                 loop = False
                 base = None
                 for msg in pkg_msgs:
-                    if msg.endswith('ActionGoal'):
+                    if msg.endswith("ActionGoal"):
                         # we have one
                         base = msg[:-10]
                         break
@@ -256,23 +261,23 @@ class Message(Scope):
                     if i == len(pkg_msgs):
                         break
                 """
-                for suffix in ('Action', 'ActionGoal', 'ActionFeedback', 'ActionResult'):
-                    pkg_msgs.remove(base+suffix)
+                for suffix in (
+                    "Action",
+                    "ActionGoal",
+                    "ActionFeedback",
+                    "ActionResult",
+                ):
+                    pkg_msgs.remove(base + suffix)
                 # add to the ROS1_action
-                root['ROS1_action'][pkg] = root['ROS1_action'].get(
-                    pkg, []) + [base+"Action"]
+                root["ROS1_action"][pkg] = root["ROS1_action"].get(pkg, []) + [
+                    base + "Action"
+                ]
                 # and look for more actions
                 loop = True
         # all parsed,
 
         # save to DB
-        MovaiDB('local').set({
-            'System': {
-                'PortsData': {
-                    "Value": root
-                }
-            }
-        })
+        MovaiDB("local").set({"System": {"PortsData": {"Value": root}}})
 
         # this could not return
         return root
@@ -282,18 +287,16 @@ class Message(Scope):
     @staticmethod
     def fetch_portdata_api() -> dict:
         """Retrieve data from database -> Called from a cloud function"""
-        return MovaiDB('local').get({
-            'System': {
-                'PortsData': '**'
-            }
-        })['System']['PortsData']['Value']
+        return MovaiDB("local").get({"System": {"PortsData": "**"}})["System"][
+            "PortsData"
+        ]["Value"]
 
     @staticmethod
     def fetch_portdata_messages() -> dict:
         """Retrieve all the messages and services available for callbacks"""
         portdata = Message.fetch_portdata_api()
-        msgs = portdata['ROS1_msg']
-        srvs = portdata['ROS1_srv']
+        msgs = portdata["ROS1_msg"]
+        srvs = portdata["ROS1_srv"]
         merged_msgs = {**msgs, **srvs}
         for key, value in merged_msgs.items():
             if key in msgs and key in srvs:
@@ -304,15 +307,14 @@ class Message(Scope):
     def get_structure(message: str) -> dict:
         """Gives the full structure of a message given the 'package/message' input"""
         rospack = rospkg.RosPack()
-        package, msg_name = message.split('/')
+        package, msg_name = message.split("/")
         try:  # MESSAGE
             # print(rosmsg.get_msg_text(message))
             search_path = {}
 
             for p in rospack.list():
                 package_paths = rosmsg._get_package_paths(p, rospack)
-                search_path[p] = [os.path.join(d, 'msg')
-                                  for d in package_paths]
+                search_path[p] = [os.path.join(d, "msg") for d in package_paths]
 
             context = genmsg.MsgContext.create_default()
 
@@ -320,8 +322,8 @@ class Message(Scope):
 
             genmsg.load_depends(context, spec, search_path)
 
-            msg_structure = {'msg': {}}
-            iterate_message(context, spec, msg_structure['msg'])
+            msg_structure = {"msg": {}}
+            iterate_message(context, spec, msg_structure["msg"])
 
         except:  # SERVICE
             try:
@@ -330,21 +332,18 @@ class Message(Scope):
 
                 for p in rospack.list():
                     package_paths = rosmsg._get_package_paths(p, rospack)
-                    msg_search_path[p] = [os.path.join(
-                        d, 'msg') for d in package_paths]
-                    srv_search_path[p] = [os.path.join(
-                        d, 'srv') for d in package_paths]
+                    msg_search_path[p] = [os.path.join(d, "msg") for d in package_paths]
+                    srv_search_path[p] = [os.path.join(d, "srv") for d in package_paths]
 
                 context = genmsg.MsgContext.create_default()
 
-                spec = genmsg.load_srv_by_type(
-                    context, message, srv_search_path)
+                spec = genmsg.load_srv_by_type(context, message, srv_search_path)
                 genmsg.load_depends(context, spec, msg_search_path)
-                msg_structure = {'srv': {'request': {}, 'response': {}}}
-                iterate_message(context, spec.request,
-                                msg_structure['srv']['request'])
-                iterate_message(context, spec.response,
-                                msg_structure['srv']['response'])
+                msg_structure = {"srv": {"request": {}, "response": {}}}
+                iterate_message(context, spec.request, msg_structure["srv"]["request"])
+                iterate_message(
+                    context, spec.response, msg_structure["srv"]["response"]
+                )
 
             except:  # LETS TRY IN REDIS
                 try:  # MESSAGE
@@ -352,28 +351,32 @@ class Message(Scope):
                     try:
                         text = Message(package).Msg[msg_name].Source
                         spec = genmsg.msg_loader.load_msg_from_string(
-                            context, text, msg_name)
-                        msg_structure = {'msg': {}}
-                        iterate_message(context, spec, msg_structure['msg'])
+                            context, text, msg_name
+                        )
+                        msg_structure = {"msg": {}}
+                        iterate_message(context, spec, msg_structure["msg"])
                     except:  # SERVICE
                         text = Message(package).Srv[msg_name].Source
-                        text_in, text_out = text.split('---')
+                        text_in, text_out = text.split("---")
                         msg_in = genmsg.msg_loader.load_msg_from_string(
-                            context, text_in, '%sRequest' % (msg_name))
+                            context, text_in, "%sRequest" % (msg_name)
+                        )
                         msg_out = genmsg.msg_loader.load_msg_from_string(
-                            context, text_out, '%sResponse' % (msg_name))
-                        spec = genmsg.srvs.SrvSpec(
-                            msg_in, msg_out, text, msg_name)
-                        msg_structure = {
-                            'srv': {'request': {}, 'response': {}}}
-                        iterate_message(context, spec.request,
-                                        msg_structure['srv']['request'])
-                        iterate_message(context, spec.response,
-                                        msg_structure['srv']['response'])
+                            context, text_out, "%sResponse" % (msg_name)
+                        )
+                        spec = genmsg.srvs.SrvSpec(msg_in, msg_out, text, msg_name)
+                        msg_structure = {"srv": {"request": {}, "response": {}}}
+                        iterate_message(
+                            context, spec.request, msg_structure["srv"]["request"]
+                        )
+                        iterate_message(
+                            context, spec.response, msg_structure["srv"]["response"]
+                        )
 
                 except:
                     print(
-                        'Cannot locate structure for Message or Service "%s"' % message)
+                        'Cannot locate structure for Message or Service "%s"' % message
+                    )
                     return {}
 
         # try:
@@ -387,8 +390,8 @@ class Message(Scope):
 def iterate_message(context, spec, struct):
 
     for type_, name in zip(spec.types, spec.names):
-        struct[name] = {'type': type_, 'content': {}}
+        struct[name] = {"type": type_, "content": {}}
         base_type = genmsg.msgs.bare_msg_type(type_)
         if not base_type in genmsg.msgs.BUILTIN_TYPES:
             subspec = context.get_registered(base_type)
-            iterate_message(context, subspec, struct[name]['content'])
+            iterate_message(context, subspec, struct[name]["content"])

--- a/dal/scopes/role.py
+++ b/dal/scopes/role.py
@@ -9,15 +9,16 @@
 """
 from dal.scopes.scope import Scope
 
+
 class Role(Scope):
 
-    scope = 'Role'
+    scope = "Role"
 
-    def __init__(self, name, version='latest', new=False, db='global'):
+    def __init__(self, name, version="latest", new=False, db="global"):
         super().__init__(scope="Role", name=name, version=version, new=new, db=db)
 
     def create_permission(self, resource: str, permission: str) -> bool:
-        """ Create new role permission """
+        """Create new role permission"""
         try:
             resource = resource.lower().capitalize()
             permission = permission.lower()
@@ -36,7 +37,7 @@ class Role(Scope):
         return True
 
     def delete_permission(self, resource: str, permission: str) -> bool:
-        """ Delete role permission """
+        """Delete role permission"""
         try:
             resource = resource.lower().capitalize()
             permission = permission.lower()
@@ -60,17 +61,19 @@ class Role(Scope):
 
     @classmethod
     def create(cls, *, name: str, resources: dict) -> bool:
-        """ Create a new role """
+        """Create a new role"""
         try:
             name = name.lower()
             new_role = Role(name, new=True)
             new_role.Label = name
-            new_role.Resources.update({
-                'User': resources.get('User', []),
-                'Flow': resources.get('Flow', []),
-                'Callbacks': resources.get('Callbacks', []),
-                'Applications': resources.get('Applications', []),
-            })
+            new_role.Resources.update(
+                {
+                    "User": resources.get("User", []),
+                    "Flow": resources.get("Flow", []),
+                    "Callbacks": resources.get("Callbacks", []),
+                    "Applications": resources.get("Applications", []),
+                }
+            )
         except Exception as e:
             return False
 
@@ -78,17 +81,19 @@ class Role(Scope):
 
     @classmethod
     def update(cls, *, name: str, resources: dict) -> bool:
-        """ Reset role data """
+        """Reset role data"""
         try:
             name = name.lower()
             role = Role(name)
             role.Label = name
-            role.Resources.update({
-                'User': resources.get('User', []),
-                'Flow': resources.get('Flow', []),
-                'Callbacks': resources.get('Callbacks', []),
-                'Applications': resources.get('Applications', []),
-            })
+            role.Resources.update(
+                {
+                    "User": resources.get("User", []),
+                    "Flow": resources.get("Flow", []),
+                    "Callbacks": resources.get("Callbacks", []),
+                    "Applications": resources.get("Applications", []),
+                }
+            )
         except Exception as e:
             return False
 

--- a/dal/scopes/user.py
+++ b/dal/scopes/user.py
@@ -1,0 +1,263 @@
+"""
+   Copyright (C) Mov.ai  - All Rights Reserved
+   Unauthorized copying of this file, via any medium is strictly prohibited
+   Proprietary and confidential
+
+   Developers:
+   - Manuel Silva (manuel.silva@mov.ai) - 2020
+   - Tiago Paulino (tiago@mov.ai) - 2020
+"""
+import binascii
+import hashlib
+import json
+import os
+from datetime import datetime
+import jwt
+
+from dal.scopes.scope import Scope
+from dal.models.acl import ACLManager
+from dal.data.shared.vault import (
+    JWT_ACCESS_EXPIRATION_DELTA,
+    JWT_REFRESH_EXPIRATION_DELTA,
+    JWT_SECRET_KEY,
+)
+
+global acl
+
+
+class User(Scope):
+    """User class"""
+
+    scope = "User"
+
+    def __init__(self, name, version="latest", new=False, db="global"):
+        super().__init__(scope="User", name=name, version=version, new=new, db=db)
+
+        global acl
+        acl_manager = ACLManager(user=self)
+        try:
+            acl = acl_manager.get_acl()
+        except Exception as e:
+            pass
+
+    def hash_password(self, password):
+        """Hash a password for storing"""
+        salt = hashlib.sha256(os.urandom(60)).hexdigest().encode("ascii")
+        pwdhash = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, 100000)
+        pwdhash = binascii.hexlify(pwdhash)
+        return (salt + pwdhash).decode("ascii")
+
+    def verify_password(self, provided_password):
+        """Verify a stored password against one provided by user"""
+
+        # user does not have a password yet
+        if not self.Password:
+            return provided_password == ""
+
+        salt = self.Password[:64]
+        stored_password = self.Password[64:]
+        pwdhash = hashlib.pbkdf2_hmac(
+            "sha256", provided_password.encode("utf-8"), salt.encode("ascii"), 100000
+        )
+        pwdhash = binascii.hexlify(pwdhash).decode("ascii")
+
+        return pwdhash == stored_password
+
+    def get_permissions(self, resource_name: str) -> list:
+        """Returns list of user permissions"""
+        result = {}
+        try:
+            global acl
+            resource_name = resource_name.lower().capitalize()
+            result = acl.which_permissions_all([self.Role], resource_name)
+        except Exception as e:
+            pass
+
+        return list(result)
+
+    def has_permission(
+        self, resource_name: str, permission_name: str, skip_superuser: bool = False
+    ) -> bool:
+        """Returns permission check"""
+        if not skip_superuser and self.Superuser:
+            return True
+
+        resource_name = resource_name.lower().capitalize()
+        permission_name = permission_name.lower()
+
+        # If request User == ScopeUser then has permission to Read
+        if f"{self.name}.read".lower() == permission_name:
+            return True
+
+        try:
+            global acl
+            result = acl.check(self.Role, resource_name, permission_name)
+        except Exception:
+            result = False
+
+        return result
+
+    def user_permissions(self) -> dict:
+
+        data = {
+            "role": self.get_value(key="Role"),
+            "all_roles": ACLManager.get_roles(),
+            "all_resources_permissions": ACLManager.get_permissions(),
+        }
+
+        resources_parsed_data = {}
+        for resource, permissions in data["all_resources_permissions"].items():
+
+            role = data["role"]
+
+            has_role_resource = False
+            if (
+                resource
+                in data.get("all_roles", {}).get(role, {}).get("Resources", {}).keys()
+            ):
+                has_role_resource = data["all_roles"][role]["Resources"][resource]
+
+            user_permissions = []
+            for perm in permissions:
+
+                role_perm_value = has_role_resource and (perm in has_role_resource)
+
+                perm_value = self.has_permission(
+                    resource_name=resource, permission_name=perm, skip_superuser=True
+                )
+
+                perm_dict = {"permission": perm, "value": perm_value}
+
+                if has_role_resource:
+                    perm_dict["inherited"] = role_perm_value
+
+                user_permissions.append(perm_dict)
+
+            resources_parsed_data[resource] = user_permissions
+
+        return resources_parsed_data
+
+    def get_supports(self):
+        # to_return = []
+        # node = Node('server4')
+        # for (key, ports) in node.PortsInst.items():
+        #     if ports.Template == "MovAI/WidgetAio":
+        #         to_return.append(key)
+        return []
+
+    def create_id(self):
+        """Create"""
+        fields = [
+            "APIPermission",
+            "Layout",
+            "name",
+            "Type",
+            "Version",
+            "WidgetPermission",
+            "Application",
+            "Applications",
+        ]
+
+        user_id = json.loads(json.dumps(self.get_dict()[self.scope][self.name]))
+        user_id["name"] = self.name
+        aux = list(user_id)
+
+        for key in aux:
+            if not key in fields:
+                del user_id[key]
+
+        user_id["supports"] = self.get_supports()
+
+        return user_id
+
+    def get_token(self):
+        """Generate authentication token"""
+
+        message = {
+            "sub": "token",
+            "iat": int(datetime.now().timestamp()),
+            "exp": int((datetime.now() + JWT_ACCESS_EXPIRATION_DELTA).timestamp()),
+            "username": self.name,
+            "message": self.create_id(),
+        }
+
+        token = jwt.encode(message, JWT_SECRET_KEY).decode("utf-8")
+        return token
+
+    def get_refresh_token(self):
+        """Generate refresh token"""
+
+        message = {
+            "sub": "refresh",
+            "iat": int(datetime.now().timestamp()),
+            "exp": int((datetime.now() + JWT_REFRESH_EXPIRATION_DELTA).timestamp()),
+            "username": self.name,
+            "message": self.create_id(),
+        }
+
+        token = jwt.encode(message, JWT_SECRET_KEY).decode("utf-8")
+        return token
+
+    @classmethod
+    def verify_token(cls, token):
+        """Validate if token is valid"""
+
+        try:
+            token_data = jwt.decode(token, JWT_SECRET_KEY, "RS256")
+            # ToDo check token data against other stuff.. user still exists, is active etc..
+        except jwt.ExpiredSignatureError:
+            raise ValueError("Signature expired.")
+        except jwt.DecodeError:
+            raise ValueError("JWT Error: Token could not be decoded.")
+        except jwt.InvalidTokenError:
+            raise ValueError("Invalid token.")
+
+        return token_data
+
+    @classmethod
+    def create(cls, username: str, password: str) -> bool:
+        """Create a new user
+
+        args:
+            username (str)
+            password (str)
+
+        returns:
+            obj (User)
+        """
+        obj = User(username, new=True)
+        obj.Label = username
+        obj.Password = obj.hash_password(password)
+
+        return obj
+
+    @classmethod
+    def reset(
+        cls,
+        *,
+        username: str,
+        current_pass: str = None,
+        new_pass: str,
+        confirm_pass: str,
+        validate_current_pass: bool = True,
+    ) -> bool:
+        """Reset user password
+
+        args:
+            - current_pass (str): old password
+            - new_pass (str): new password
+            - confirm_pass (str): confirm password
+            - validate_current_password (bool): confirm current password before setting the new password
+        """
+
+        if new_pass != confirm_pass:
+            raise ValueError("Confirm password does not match")
+
+        obj = User(username)
+
+        if validate_current_pass and not obj.verify_password(current_pass):
+            raise ValueError("Current password is incorrect.")
+
+        obj.Password = obj.hash_password(new_pass)
+
+        return True

--- a/dal/tools/secret_key_tool.py
+++ b/dal/tools/secret_key_tool.py
@@ -1,0 +1,194 @@
+from abc import ABC, abstractmethod
+import argparse
+from ctypes import ArgumentError
+from curses.ascii import isascii
+from errno import EEXIST, EINVAL, ENOEXEC
+
+from movai_core_shared.logger import Log
+from movai_core_shared.exceptions import (SecretKeyAlreadyExist,
+                                          SecretKeyDoesNotExist)
+
+from dal.classes.utils.secretkey import SecretKey
+
+MIN_KEY_LENGTH = 16
+MAX_KEY_LENGTH = 1024
+
+class BaseCommand(ABC):
+    """Base Class for the varios tool commands.
+    """
+    log = Log.get_logger('BaseCommand')
+    def __init__(self, **kwargs) -> None:
+        """initializes the object and extract commnad arguments.
+        """
+        self.command = kwargs['command']
+        self.name = kwargs.get('name')
+        self.length = kwargs.get('length', 32)
+        self.log.debug(f"executing {self.command} command.")
+
+    def __call__(self) -> any:
+        """Executes the relevant command
+
+        Returns:
+            any: returns the command output.
+        """
+        try:
+            return self.execute()
+        except SecretKeyDoesNotExist as e:
+            print(e)
+            return ENOEXEC
+        except SecretKeyAlreadyExist as e:
+            print(e)
+            return EEXIST
+        except ArgumentError as e:
+            print(e)
+            return EINVAL
+
+    def fail_argument(self, arg_name: str):
+        """A general function for raising ArgumentError.
+
+        Args:
+            arg_name (str): The name of the argument to check
+
+        Raises:
+            ArgumentError: In case the argument is missing.
+        """
+        error_msg = f"Can't execute {self.command} command, the {arg_name} argument is missing."
+        raise ArgumentError(error_msg)
+
+    def check_name(self):
+        """Checks the name argument
+        """
+        error = False
+        if self.name is None:
+            self.fail_argument('name')
+        if not isinstance(self.name, str):
+            self.fail_argument('name')
+        for letter in self.name:
+            if not isascii(letter):
+                self.fail_argument('name')
+
+    def check_length(self):
+        """Checks the legnth argument
+
+        Raises:
+            ArgumentError: in case the length argument is missing or his value
+                is not in the allowed range.
+        """
+        if self.length is None:
+            self.fail_argument('length')
+        elif self.length < 16 or self.length > 1024:
+            error_msg = f"Can't execute {self.command} command,"\
+                        f"the length argument must be in the range {MIN_KEY_LENGTH} to {MAX_KEY_LENGTH}."
+            raise ArgumentError(error_msg)
+            
+
+    @abstractmethod
+    def execute(self) -> int:
+        """Abstract funtion for exuting command.
+
+        Returns:
+            any: output from the command.
+        """
+
+
+class CreateCommand(BaseCommand):
+    """Creates an new secret key in DB.
+    
+    Args:
+        name (str) - the name of the key object in DB.
+        length (int) - the size of the key in characters.
+    """
+    def execute(self) -> int:
+        self.check_name()
+        self.check_length()
+        SecretKey.create(self.name, self.length)
+        print(f"successfully created {self.name} secret key.")
+        return 0
+
+
+class RemoveCommand(BaseCommand):
+    """Removes a key from DB.
+    
+    Args:
+        name (str) - the name of the key object in DB.
+    """
+    def execute(self) -> int:
+        self.check_name()
+        SecretKey.remove(self.name)
+        print(f"successfully removed {self.name} secret key.")
+        return 0
+
+class UpdateCommand(BaseCommand):
+    """Updates a key in DB.
+    
+    Args:
+        name (str) - the name of the key object in DB.
+        length (int) - the size of the key in characters.
+    """
+    def execute(self) -> int:
+        self.check_name()
+        self.check_length()
+        SecretKey.update(self.name, self.length)
+        print(f"successfully updated {self.name} secret key.")
+        return 0
+
+
+class ShowCommand(BaseCommand):
+    """Dispalys the the key on the user terminal.
+    """
+    def execute(self) -> int:
+        self.check_name()
+        print(f"Secret: {SecretKey.get_secret(self.name)}")
+        return 0
+
+
+class SecretKeyTool:
+    """A class for executing the correct command
+    """
+    commands = {'create': CreateCommand,
+                'remove': RemoveCommand,
+                'update': UpdateCommand,
+                'show': ShowCommand}
+
+    def __call__(self, **kwargs):
+        """initialize the tool and execute the command.
+        """
+        if 'command' not in kwargs:
+            error_msg = f"Can not find the command field in kwargs dictionary."
+            print(error_msg)
+            return EINVAL
+        command = kwargs['command']
+        if command not in self.commands:
+            error_msg = f"Unknown command: {command}"
+            print(error_msg)
+            return EINVAL
+        command_type = self.commands[command]
+        command_obj = command_type(**kwargs)
+        return command_obj()
+        
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Create a secret key for Mov.ai fleet.")
+    parser.add_argument("-c", "--command",
+                        help="create - creates a new key with the specified name"\
+                             "remove - removes the key with the specified name"\
+                             "update - updates the key with the specified name"\
+                             "show - displays thecontents of key with the specified name"\
+                             "list - list all available keys on current robot",
+                        type=str,
+                        required=True)
+    parser.add_argument("-n", "--name",
+                        help="key name",
+                        type=str,
+                        required=False)
+    parser.add_argument("-l", "--length",
+                        help=f"key length, default = 64, {MIN_KEY_LENGTH} =< length =< {MAX_KEY_LENGTH}",
+                        type=int,
+                        required=False)
+
+    args, _ = parser.parse_known_args()
+
+    key = SecretKeyTool()
+    exit(key(**vars(args)))

--- a/dal/validation/template.py
+++ b/dal/validation/template.py
@@ -7,7 +7,7 @@
    - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
 """
 from types import SimpleNamespace
-from dal.plugins import Resource, ResourceException
+from dal.plugins.resource import Resource, ResourceException
 
 
 class Template:  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
* black formatting

* deprecated.api.core.shared.py moved to dal.classes.common

* movai.remote.archive moved to dal

* fixing import path

* the file is duplicated by gd_node.shared.py

* statemachine scope moved back to dal

* Message scope moved to dal from gd-node

* update import path

* update gd_node import

* replace acl with updated one and move it dal.classes.utils

* backend.models moved to dal

* backend scopes moved to dal

* backend.core.secretkey moved to dal

* backend.tools.secret_key_tool moved to dal

* backend.core.token moved to dal

* update import path

* restoring API2 excluding User, BaseUser, RemoteUser, InternalUser and AclObject and structure

* the following files were must be inside models folder instead of scopes folder

* updating import path for moved files

* ACLManager moved to dal.models

* API2 deprecation warning

Co-authored-by: M Mograbi <Mograbi@users.noreply.github.com>

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch**
- [ ] Ensure that the PR title represents the desired changes
- [ ] Ensure that the PR description detail the desired changes
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
