### PR TITLE
Bugfix/csai 2239/lock acquire shouldnt be persistent

### DIFF
--- a/dal/models/lock.py
+++ b/dal/models/lock.py
@@ -90,7 +90,6 @@ class Lock:
         self.persistent = persistent
 
         self.queue_level = queue_level
-        self.timeout = timeout
         self.alive_timeout = alive_timeout
         self.robot_name = _robot_name or Robot().name
         self.node_name = _node_name
@@ -102,7 +101,7 @@ class Lock:
         if timeout == 0:
             # default timeout time
             timeout = self.DEFAULT_LOCK_TIMEOUT
-            self.should_reacquire = True
+        self.timeout = timeout
         self.db_lock = self.db_write.lock(self.lock_name, timeout=timeout,
                                           blocking_timeout=blocking_timeout,
                                           thread_local=False)


### PR DESCRIPTION
bug fix to change behavior

previously when using lock without any parameter lock()
the lock was set forever (without any timeout)
so this commit changes this behavior so that the default will be 90 seconds
meaning lock() is like lock(timeout=90)

to check it:
please go inside the spawner container and run

a = Lock('a')
a.acquire() # print: True
a.inspect() # should see ('f8db180f07a5438bae3180f95fc16daa', []) or something else in the first part
# wait 90 seconds
a.inspect() # should see (None, [])

jira:
https://movai.atlassian.net/browse/CSAI-2239
- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
