### PR TITLE
removed redundant del before set

### DIFF
--- a/dal/movaidb/database.py
+++ b/dal/movaidb/database.py
@@ -459,7 +459,6 @@ class MovaiDB:
                             hkey: pickle.dumps(hval) for hkey, hval in value.items()
                         }
                         if value:
-                            db_set.delete(key)
                             db_set.hmset(key, value)
                     elif source == "list":
                         for lval in value:


### PR DESCRIPTION
- [BP-910](https://movai.atlassian.net/browse/BP-910): Redis subscriber update gives a del event before updating

[BP-910]: https://movai.atlassian.net/browse/BP-910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ