### PR TITLE
Fix updating a fleet member firmware overwrite redis-master DB

### DIFF
--- a/dal/tools/backup.py
+++ b/dal/tools/backup.py
@@ -1906,30 +1906,42 @@ def main():
 
     project = args.project
     recursive = not args.individual
+    
+    redis_master_host = os.getenv("REDIS_MASTER_HOST", "None")
+    redis_write = (redis_master_host == "redis-master")
+        
     if args.action == "import":
-        tool = Importer(
-            project,
-            force=args.force,
-            dry=args.dry,
-            debug=args.debug,
-            root_path=args.root_path,
-            recursive=recursive,
-            clean_old_data=args.clean_old_data,
-        )
+        if redis_write:
+            tool = Importer(
+                project,
+                force=args.force,
+                dry=args.dry,
+                debug=args.debug,
+                root_path=args.root_path,
+                recursive=recursive,
+                clean_old_data=args.clean_old_data,
+            )
+        else:
+            print("Skipping importer...")
+            exit(0)
     elif args.action == "export":
         tool = Exporter(
             project, debug=args.debug, root_path=args.root_path, recursive=recursive
         )
     elif args.action == "remove":
-        tool = Remover(
-            force=args.force,
-            dry=args.dry,
-            debug=args.debug,
-            root_path=args.root_path,
-            recursive=recursive,
-        )
-        # so the action print is not 'Removeed'
-        args.action = args.action[:-1]
+        if redis_write:
+           tool = Remover(
+               force=args.force,
+               dry=args.dry,
+               debug=args.debug,
+               root_path=args.root_path,
+               recursive=recursive,
+           )
+           # so the action print is not 'Removeed'
+           args.action = args.action[:-1]
+       else:
+           print("Skipping remover...")
+           exit(0)
     else:
         print(f"Unknown action {args.action}")
         exit(1)

--- a/dal/tools/backup.py
+++ b/dal/tools/backup.py
@@ -17,6 +17,7 @@ import argparse
 import sys
 import re
 from importlib import import_module
+from movai_core_shared.envvars import REDIS_MASTER_HOST
 
 from dal.movaidb import MovaiDB
 from dal.models.scopestree import scopes
@@ -1907,8 +1908,7 @@ def main():
     project = args.project
     recursive = not args.individual
     
-    redis_master_host = os.getenv("REDIS_MASTER_HOST", "None")
-    redis_write = (redis_master_host == "redis-master")
+    redis_write = (REDIS_MASTER_HOST == "redis-master")
         
     if args.action == "import":
         if redis_write:


### PR DESCRIPTION
# Content
- bump versions
- restore linting configurations files
- fix metadata import tools/backup.py: https://movai.atlassian.net/browse/DP-1047

Now using an ENV var which is set in spawner, backend, health-node to identify if the metadata needs to be installed:
- in a manager : REDIS_MASTER_HOST is set to redis-master (inside container hostname)
- in a fleet member : REDIS_MASTER_HOST is set to haproxy (outside host proxied by haproxy)

```
    redis_master_host = os.getenv("REDIS_MASTER_HOST", "None")
    if redis_master_host in "redis-master":
        redis_write = True
    else:
        redis_write = False
```


---

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

