### PR TITLE
Hotfix/remove-API2-imports-from-backup-tool

### DIFF
--- a/dal/tools/backup.py
+++ b/dal/tools/backup.py
@@ -18,8 +18,8 @@ import pickle
 import re
 import sys
 
-from API2.Layer1 import MovaiDB
-from movai.data import scopes
+from dal.movaidb.database import MovaiDB
+from dal.models.scopestree import scopes
 
 
 def test_reachable(redis_url):


### PR DESCRIPTION
update imports to not use movai-web-api2 repo 