### PR TITLE
BP-1166 : get default values of subflows when no instance value is set

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.4.2-0
+current_version = 2.4.1-36
 commit = True
 message =
 	[SKIP] Automatic version bump {current_version} -> {new_version}

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,11 +1,5 @@
 [MESSAGES CONTROL]
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        no-self-use,
-        logging-fstring-interpolation
+disable=logging-fstring-interpolation
 ignore=setup.py,
 ignore-patterns=.*_test.*?py,.*test_.*?py,.*test.*?py,.*pb2.*,.*yml, .*toml, .*txt, .*md
 

--- a/dal/helpers/parsers.py
+++ b/dal/helpers/parsers.py
@@ -87,9 +87,7 @@ class ParamParser:
 
         return expression
 
-    def eval_reference(
-        self, key: str, expression: str, instance: any, node_name: str
-    ) -> str:
+    def eval_reference(self, key: str, expression: str, instance: any, node_name: str) -> str:
         """
         Calls a specific function to evaluate the expression
 
@@ -109,9 +107,7 @@ class ParamParser:
         try:
             # $(<context> <parameter reference>)
             # ex.: $(flow var_A)
-            pattern = re.compile(
-                rf"\$\(({'|'.join(self.mapping.keys())})\s+([\w\.-]+)\)"
-            )
+            pattern = re.compile(rf"\$\(({'|'.join(self.mapping.keys())})\s+([\w\.-]+)\)")
             result = pattern.search(expression)
 
             if result is None:
@@ -126,7 +122,9 @@ class ParamParser:
             extra_info = f'in flow "{self.flow.ref}"'
 
             if self.context != self.flow.ref:
-                extra_info = f'in subflow "{self.context}" in the context of the flow "{self.flow.ref}"'
+                extra_info = (
+                    f'in subflow "{self.context}" in the context of the flow "{self.flow.ref}"'
+                )
 
             info = (
                 f'Error evaluating "{key}" with value "{expression}"'
@@ -156,16 +154,14 @@ class ParamParser:
         try:
             obj = scopes.from_path(_config_name, scope="Configuration")
 
-        except KeyError as e:
-            raise Exception(f"Configuration {_config_name} does not exist") from e
+        except KeyError as exc:
+            raise Exception(f"Configuration {_config_name} does not exist") from exc
 
         output = obj.get_param(_config_param)
 
         return output
 
-    def eval_param(
-        self, param_name: str, default: str, instance: any, node_name: str
-    ) -> any:
+    def eval_param(self, param_name: str, default: str, instance: any, node_name: str) -> any:
         """
         Returns the param expression evaluated or default
             ex.: $(param name)
@@ -226,8 +222,8 @@ class ParamParser:
 
         node_name_arr = node_name.split("__")
         # Check if this is the main flow or a subflow
-        is_subflow = True if len(node_name_arr) > 1 else False
-        value = instance.flow.get_param(param_name, self.context, is_subflow = is_subflow)
+        is_subflow = len(node_name_arr) > 1
+        value = instance.flow.get_param(param_name, self.context, is_subflow=is_subflow)
         if value is None:
             value = default
 
@@ -247,7 +243,9 @@ class ParamParser:
 
                     # get the instance parameter value
                     # if there is no instance param, set to default
-                    ctr_value = ctr_instance.get_param(param_name, _name, self.context, default_value = value)
+                    ctr_value = ctr_instance.get_param(
+                        param_name, _name, self.context, default_value=value
+                    )
 
                     value = value if ctr_value is None else ctr_value
 
@@ -268,10 +266,7 @@ def get_string_from_template(template: str, task_entry: object) -> str:
         try:
             template, enum = match[1].split(".")
             return str(
-                scopes()
-                .SharedDataEntry[task_entry.SharedData[template].ID]
-                .Field[enum]
-                .Value
+                scopes().SharedDataEntry[task_entry.SharedData[template].ID].Field[enum].Value
             )
         except Exception:  # pylint: disable=broad-except
             # ValueError from split/unpack

--- a/dal/helpers/parsers.py
+++ b/dal/helpers/parsers.py
@@ -225,8 +225,9 @@ class ParamParser:
         """
 
         node_name_arr = node_name.split("__")
-
-        value = instance.flow.get_param(param_name, self.context)
+        # Check if this is the main flow or a subflow
+        is_subflow = True if len(node_name_arr) > 1 else False
+        value = instance.flow.get_param(param_name, self.context, is_subflow = is_subflow)
         if value is None:
             value = default
 
@@ -244,8 +245,9 @@ class ParamParser:
                     # get the container instance
                     ctr_instance = self.flow.get_container(_name, self.context)
 
-                    # get the parameter value
-                    ctr_value = ctr_instance.get_param(param_name, _name, self.context)
+                    # get the instance parameter value
+                    # if there is no instance param, set to default
+                    ctr_value = ctr_instance.get_param(param_name, _name, self.context, default_value = value)
 
                     value = value if ctr_value is None else ctr_value
 

--- a/dal/models/container.py
+++ b/dal/models/container.py
@@ -50,7 +50,8 @@ class Container(ScopeObjectNode):
     def get_param(self, key: str,
                   name: str = None,
                   context=None,
-                  custom_parser: any = None) -> any:
+                  custom_parser: any = None,
+                  default_value: any = None) -> any:
         """
         Returns a specific parameter of the container after
         parsing it
@@ -67,7 +68,7 @@ class Container(ScopeObjectNode):
         try:
             _value = self.Parameter[key].Value
         except KeyError:
-            _value = None
+            _value = default_value
 
         # parse the parameter
         output = _parser.parse(key, str(_value), _name, self, _context)

--- a/dal/models/flow.py
+++ b/dal/models/flow.py
@@ -7,22 +7,23 @@
    - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
    - Manuel Silva  (manuel.silva@mov.ai) - 2020
 """
+import re
 from types import SimpleNamespace
-from movai_core_shared.consts import (ROS1_NODELETSERVER)
-from movai_core_shared.logger import Log
 
-from .flowlinks import FlowLinks
-from .scopestree import scopes
 from dal.helpers.flow import GFlow
 from dal.helpers.parsers import ParamParser
+from movai_core_shared.consts import ROS1_NODELETSERVER
+from movai_core_shared.logger import Log
+
 from .model import Model
-import re
+from .scopestree import scopes
 
 
 class Flow(Model):
     """
     A Flow
     """
+
     __RELATIONS__ = {
         "schemas/1.0/Flow/NodeInst/Template": {
             "schema_version": "1.0",
@@ -31,7 +32,7 @@ class Flow(Model):
         "schemas/1.0/Flow/Container/ContainerFlow": {
             "schema_version": "1.0",
             "scope": "Flow",
-        }
+        },
     }
 
     __START__ = "START/START/START"
@@ -51,7 +52,7 @@ class Flow(Model):
 
     @property
     def full(self) -> dict:
-        """ Returns the data from the main flow and all subflows """
+        """Returns the data from the main flow and all subflows"""
 
         self._full = self._full or self.get_dict()
 
@@ -59,36 +60,36 @@ class Flow(Model):
 
     @property
     def parser(self) -> ParamParser:
-        """ Get or create and instance of the parser """
+        """Get or create and instance of the parser"""
 
         return self._parser or self._create_parser_instance()
 
     @property
     def graph(self) -> GFlow:
-        """ Get or create an instance of the graph generator """
+        """Get or create an instance of the graph generator"""
 
         return self._graph or self._create_graph_instance()
 
     @property
     def remaps(self) -> dict:
-        """ Get remaps from the graph instance """
+        """Get remaps from the graph instance"""
 
         return self.graph.get_remaps()
 
     def _create_parser_instance(self) -> ParamParser:
-        """ Create and instance of the parser """
+        """Create and instance of the parser"""
 
         self._parser = self.__PARAM_PARSER__(self)
         return self._parser
 
     def _create_graph_instance(self) -> GFlow:
-        """ Create an instance of the graph generator """
+        """Create an instance of the graph generator"""
 
         self._graph = self.__GRAPH_GEN__(self)
         return self._graph
 
     def _with_prefix(self, prefix: str, nodes: dict, links: dict) -> dict:
-        """"
+        """ "
         Add a prefix to the node instances and also to the links
         """
         output = SimpleNamespace(NodeInst={}, Links={})
@@ -99,8 +100,7 @@ class Flow(Model):
 
             pref_id = f"{prefix}{_id}"
 
-            output.NodeInst.update(
-                {pref_id: node_inst})
+            output.NodeInst.update({pref_id: node_inst})
 
         for _id, value in links:
 
@@ -109,12 +109,10 @@ class Flow(Model):
             _from = value["From"]
             _to = value["To"]
 
-            _value["From"] = f"{prefix}{_from}" if _from.upper(
-            ) != self.__START__ else _from
+            _value["From"] = f"{prefix}{_from}" if _from.upper() != self.__START__ else _from
 
             _value["To"] = f"{prefix}{_to}"
-            _value["Dependency"] = value.get(
-                "Dependency", self.Links.__DEFAULT_DEPENDENCY__)
+            _value["Dependency"] = value.get("Dependency", self.Links.__DEFAULT_DEPENDENCY__)
 
             # required for legacy compatibility
             output.Links.update({pref_id: _value})
@@ -138,12 +136,10 @@ class Flow(Model):
         prev_flows = prev_flows or []
 
         if self.ref in prev_flows:
-            raise RecursionError(
-                "Flow already in use, this will lead to infinite recursion")
+            raise RecursionError("Flow already in use, this will lead to infinite recursion")
 
         # start creating the dict
-        output = data or self._with_prefix(
-            "", self.NodeInst.items(), self.Links.items())
+        output = data or self._with_prefix("", self.NodeInst.items(), self.Links.items())
 
         for _, container in self.Container.items():
 
@@ -155,8 +151,7 @@ class Flow(Model):
             label = f"{_prefix}{container.ContainerLabel}"
 
             # extract subflow data
-            wprefix = subflow._with_prefix(
-                label, subflow.NodeInst.items(), subflow.Links.items())
+            wprefix = subflow._with_prefix(label, subflow.NodeInst.items(), subflow.Links.items())
 
             # update main dict
             output.NodeInst.update(wprefix.NodeInst)
@@ -172,7 +167,7 @@ class Flow(Model):
         return output
 
     def get_node_params(self, node_name: str, context: str = None) -> dict:
-        ''' Returns the parameters of the node instance '''
+        """Returns the parameters of the node instance"""
 
         # TODO rename to get_node_inst_params ?
 
@@ -194,14 +189,13 @@ class Flow(Model):
             return self.full.NodeInst[name]
 
         except KeyError as e:
-            raise KeyError(
-                f"Node instance '{name}' does not exist in '{self.ref}'") from e
+            raise KeyError(f"Node instance '{name}' does not exist in '{self.ref}'") from e
 
     def get_container(self, name: str, context: str = None):
-        """ Returns an instance of Container """
+        """Returns an instance of Container"""
 
         # each element represents a container, aka subflow
-        node_name_arr = name.split('__')
+        node_name_arr = name.split("__")
 
         _container = None
         _flow = self
@@ -222,17 +216,17 @@ class Flow(Model):
         return _container
 
     def get_node(self, node_inst_name: str):
-        '''
+        """
         Returns an instance of Node (template)
-        '''
+        """
         # TODO check if method is still in use
 
         return self.NodeInst[node_inst_name].node_template
 
     def get_start_nodes(self) -> list:
-        '''
+        """
         Returns all node instances with a link to the START node
-        '''
+        """
 
         output = []
 
@@ -273,13 +267,13 @@ class Flow(Model):
         return output
 
     def get_node_inst_param(self, name: str, key: str, context: str = None) -> any:
-        """ Returns the node instance parameter """
+        """Returns the node instance parameter"""
         _context = context or self.ref
 
         return self.get_node_inst(name).get_param(key, name, _context)
 
     def get_lifecycle_nodes(self) -> list:
-        """ List of Ros2 Lifecycle Nodes """
+        """List of Ros2 Lifecycle Nodes"""
         output = []
 
         for _, node_inst in self.full.NodeInst.items():
@@ -292,7 +286,7 @@ class Flow(Model):
         return output
 
     def get_node_transitions(self, node_inst: str, port_name: str = None) -> set:
-        """ Returns a list of nodes to transit to """
+        """Returns a list of nodes to transit to"""
 
         transition_nodes = set()
 
@@ -307,12 +301,12 @@ class Flow(Model):
 
         for link in links:
 
-            _type = link["Type"]   # From or To
+            _type = link["Type"]  # From or To
             # TODO confirm this fix
-            if _type == 'To':
+            if _type == "To":
                 continue
-            _plink = getattr(link["ref"], _type)   # Get partial link from ref
-            _port_type = "In" if _type is "To" else "Out"
+            _plink = getattr(link["ref"], _type)  # Get partial link from ref
+            _port_type = "In" if _type == "To" else "Out"
 
             # get the Ports instance from the Node template
             port_tpl = node_tpl.get_port(_plink.port_name)
@@ -320,11 +314,14 @@ class Flow(Model):
             def filter_by_port(fnport, lnport):
                 return True if fnport is None else fnport == lnport
 
-            if port_tpl.is_transition(_port_type, _plink.port_type) and filter_by_port(port_name, _plink.port_name):
+            if port_tpl.is_transition(_port_type, _plink.port_type) and filter_by_port(
+                port_name, _plink.port_name
+            ):
 
                 # get the node_inst to transit to
-                to_transit = getattr(link["ref"], "From") if _type == "To" else getattr(
-                    link["ref"], "To")
+                to_transit = (
+                    getattr(link["ref"], "From") if _type == "To" else getattr(link["ref"], "To")
+                )
 
                 # FIXME give as models.NodeInst object
                 transition_nodes.add(to_transit.node_inst)
@@ -333,7 +330,7 @@ class Flow(Model):
         return transition_nodes
 
     def get_nodelet_manager(self, node_inst: str) -> str:
-        """ Returns nodelet manager name """
+        """Returns nodelet manager name"""
         output = None
 
         # get the node_inst instance ref
@@ -348,11 +345,11 @@ class Flow(Model):
 
         for link in links:
 
-            if link['ref'].From.node_inst != node_inst:
+            if link["ref"].From.node_inst != node_inst:
                 continue
 
             # Get the manager part (To)
-            _plink = link['ref'].To
+            _plink = link["ref"].To
 
             # get the node inst manager
             node_inst_mng = self.get_node_inst(_plink.node_inst)
@@ -367,9 +364,14 @@ class Flow(Model):
         return output
 
     def get_node_dependencies(
-            self, node_name: str, dependencies_collected: list = None, links_to_skip: list = None,
-            skip_parent_node: str = None, first_level_only: bool = False) -> list:
-        """ Get node dependencies recursively """
+        self,
+        node_name: str,
+        dependencies_collected: list = None,
+        links_to_skip: list = None,
+        skip_parent_node: str = None,
+        first_level_only: bool = False,
+    ) -> list:
+        """Get node dependencies recursively"""
 
         # TODO review and refactor
 
@@ -431,18 +433,18 @@ class Flow(Model):
                     dependencies.append(dependency_name)
                     if not first_level_only:
                         dependencies = self.get_node_dependencies(
-                            dependency_name, dependencies, links_to_skip, skip_parent_node)
+                            dependency_name, dependencies, links_to_skip, skip_parent_node
+                        )
 
         return list(set(dependencies))
 
     def get_node_plugins(self, node_inst: str) -> set:
-        """ Return NodeInst(s) plugins linked to node_inst """
+        """Return NodeInst(s) plugins linked to node_inst"""
 
         output = set()
 
         # get first level node dependencies
-        dependencies = self.get_node_dependencies(
-            node_name=node_inst, first_level_only=True)
+        dependencies = self.get_node_dependencies(node_name=node_inst, first_level_only=True)
 
         for dependency in dependencies:
 

--- a/dal/models/flow.py
+++ b/dal/models/flow.py
@@ -16,6 +16,7 @@ from .scopestree import scopes
 from dal.helpers.flow import GFlow
 from dal.helpers.parsers import ParamParser
 from .model import Model
+import re
 
 
 class Flow(Model):
@@ -244,7 +245,7 @@ class Flow(Model):
 
         return output
 
-    def get_param(self, key: str, context: str = None) -> any:
+    def get_param(self, key: str, context: str = None, is_subflow: bool = False) -> any:
         """
         Returns a parameter of the flow after parsing it
         """
@@ -254,6 +255,14 @@ class Flow(Model):
             param = self.Parameter[key].Value
         except KeyError:
             return None
+
+        if is_subflow:
+            # Check if instance is pointing to upper flow
+            # If so, continue to next (upper) flow
+            regex_flow = r"\$\((flow)[^$)]+\)"
+            flow_in_param = re.search(regex_flow, param)
+            if flow_in_param:
+                return param
 
         # main flow context or own context
         _context = context or self.ref

--- a/dal/models/flow.py
+++ b/dal/models/flow.py
@@ -10,11 +10,10 @@
 import re
 from types import SimpleNamespace
 
-from dal.helpers.flow import GFlow
-from dal.helpers.parsers import ParamParser
 from movai_core_shared.consts import ROS1_NODELETSERVER
 from movai_core_shared.logger import Log
-
+from dal.helpers.flow import GFlow
+from dal.helpers.parsers import ParamParser
 from .model import Model
 from .scopestree import scopes
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ data_files += [file for file in glob("dal/validation/schema/2.4/common/*.json")]
 # The 'install_requires' is where you specify the package dependencies of your package. They will be automaticly installed, before your package.  # noqa: E501
 setuptools.setup(
     name="data-access-layer",
-    version="2.4.2-0",
+    version="2.4.1-36",
     author="Backend team",
     author_email="backend@mov.ai",
     description="DATA ACCESS LAYER",


### PR DESCRIPTION
Previously if a subflow param was by default pointing  to a flow parameter and there was no value given in the instance, it would give an exception of trying split a NoneType.
In this fix, we are now checking if the default param is pointing to another flow when there is no value on the instance and moving on to check the upper flow. In case it is the main flow, we get the default param.

Test flow to validate fix is included in [BP-1166](https://movai.atlassian.net/browse/BP-1166)

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository


[BP-1166]: https://movai.atlassian.net/browse/BP-1166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ