### PR TITLE
DP-1384 : SPAWNER_BIND_ADDR switch to unix socket

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,11 +1,5 @@
 [MESSAGES CONTROL]
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        no-self-use,
-        logging-fstring-interpolation
+disable=logging-fstring-interpolation
 ignore=setup.py,
 ignore-patterns=.*_test.*?py,.*test_.*?py,.*test.*?py,.*pb2.*,.*yml, .*toml, .*txt, .*md
 

--- a/dal/scopes/robot.py
+++ b/dal/scopes/robot.py
@@ -15,8 +15,7 @@ import pickle
 from movai_core_shared.core.message_client import MessageClient
 from movai_core_shared.exceptions import DoesNotExist
 from movai_core_shared.consts import COMMAND_HANDLER_MSG_TYPE
-from movai_core_shared.envvars import SPAWNER_BIND_PORT, DEVICE_NAME
-
+from movai_core_shared.envvars import SPAWNER_BIND_ADDR, DEVICE_NAME
 
 from dal.scopes.scope import Scope
 from dal.movaidb import MovaiDB
@@ -57,7 +56,9 @@ class Robot(Scope):
 
             self.__dict__["fleet"] = FleetRobot(unique_id.hex, new=True)
             self.fleet.RobotName = "robot_" + unique_id.hex[0:6]
-        server = f"tcp://spawner:{SPAWNER_BIND_PORT}"
+
+        # default : ipc:///opt/mov.ai/comm/SpawnerServer-{DEVICE_NAME}-{FLEET_NAME}.sock"
+        server = SPAWNER_BIND_ADDR
         self.__dict__["spawner_client"] = MessageClient(server_addr=server, robot_id=self.name)
 
     def set_ip(self, ip_address: str):


### PR DESCRIPTION
ZMQ socket not working in hostmode=true

## goal
replace ZMQ communication with spawner from TCP to a unix file socket shared between containers

---
- [ ] Make sure you are opening from a **topic/feature/bugfix branch**
- [ ] Ensure that the PR title represents the desired changes
- [ ] Ensure that the PR description detail the desired changes
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
