### PR TITLE
Load MovaiBaseModel into dal.new_models

### DIFF
--- a/dal/new_models/__init__.py
+++ b/dal/new_models/__init__.py
@@ -7,6 +7,7 @@
    - Moawiya Mograbi (moawiya@mov.ai) - 2023
    - Erez Zomer (erez@mov.ai) - 2023
 """
+from .base import MovaiBaseModel
 from .callback import Callback
 from .configuration import Configuration
 from .flow import Flow
@@ -17,6 +18,7 @@ from .system import System
 
 
 __all__ = [
+    "MovaiBaseModel",
     "Callback",
     "Configuration",
     "Flow",


### PR DESCRIPTION
Tiny PR to allow us to import the class directly from `dal.new_models`.
