### PR TITLE
Don't send command to redis if response not required

### DIFF
--- a/dal/scopes/fleetrobot.py
+++ b/dal/scopes/fleetrobot.py
@@ -88,7 +88,7 @@ class FleetRobot(Scope):
         send_to_redis = False
         response_required = False
         if self.RobotName != DEVICE_NAME and is_enterprise():
-            logger.debug(f"{self.RobotName} is a fleet member")
+            logger.debug("%s is a fleet member", self.RobotName)
             response_required = True
 
         if hasattr(self, "spawner_client") and self.spawner_client is not None:
@@ -103,18 +103,18 @@ class FleetRobot(Scope):
                 and res["response"] != {}
             ):
                 # success if response is not required or if required, is well formed
-                logger.info(f"Sent command {command_data} to robot {self.RobotName}")
+                logger.info("Sent command %s to robot %s", command_data, self.RobotName)
             else:
                 logger.debug(
-                    f"Failed to send command {command_data} {self.RobotName}, response: {res}"
+                    "Failed to send command %s %s, response: %s", command_data, self.RobotName, res
                 )
                 send_to_redis = True
         else:
-            logger.debug(f"Spawner client not found for {self.RobotName}")
+            logger.debug("Spawner client not found for %s", self.RobotName)
             send_to_redis = True
 
         if send_to_redis:
-            logger.info(f"Command {command_data}, published in redis for robot {self.RobotName}")
+            logger.info("Command %s, published in redis for robot %s", command_data, self.RobotName)
             command_data = pickle.dumps(command_data)
             self.Actions.append(command_data)
 

--- a/dal/scopes/fleetrobot.py
+++ b/dal/scopes/fleetrobot.py
@@ -95,9 +95,8 @@ class FleetRobot(Scope):
             res = self.spawner_client.send_request(
                 COMMAND_HANDLER_MSG_TYPE, req_data, respose_required=response_required
             )
-            if (
-                not response_required
-                or response_required
+            if (not response_required) or (
+                response_required
                 and res is not None
                 and "response" in res
                 and res["response"] != {}


### PR DESCRIPTION
- [BP-1194](https://movai.atlassian.net/browse/BP-1194): Flow is started multiple times which leads to weird behavior
  - When https://github.com/MOV-AI/data-access-layer/pull/205 was merged, a condition was missed
  - Added a few more logs, if you think they are too much just let mw know

The condition `if hasattr(self, "spawner_client")` seems redundant, should it be removed?

[BP-1194]: https://movai.atlassian.net/browse/BP-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ