### PR TITLE
[BP-1195] Overwrite of one annotation in a trajectories seems to affect all trajectories with same annotation

### DIFF
--- a/dal/models/configuration.py
+++ b/dal/models/configuration.py
@@ -37,17 +37,10 @@ class Configuration(Model):
         if self.Type == "xml":
             # Yaml is the name of the field
             return self.Yaml
-
-        # self.Yaml will be set once we load configuration and remain the same
-        # until we update the self.Yaml explicitly unlike Configuration(Scope)
-        db_yaml = self._get_db_yaml()
-        if db_yaml != self.Yaml or self.ref not in self.cache:
-            # we need to update it because of the scopes caching system
-            _data = yaml.load(db_yaml, Loader=yaml.FullLoader)
-            self.cache[self.ref] = _data
-            self.Yaml = db_yaml
-
-        return self.cache[self.ref]
+        
+        # Don't need to go to DB because the schema is already loaded in the constructor of the class
+        # TODO: We can implement a proper caching system later to save this yaml.load operation
+        return yaml.load(self.Yaml, Loader=yaml.FullLoader)
 
     def get_param(self, param: str) -> any:
         """Returns the configuration value of a key in the format param.subparam.subsubparam"""

--- a/dal/models/configuration.py
+++ b/dal/models/configuration.py
@@ -39,7 +39,7 @@ class Configuration(Model):
             return self.Yaml
         
         # Don't need to go to DB because the schema is already loaded in the constructor of the class
-        # TODO: We can implement a proper caching system later to save this yaml.load operation
+        # TODO:We can implement a proper caching system later to save this yaml.load operation
         return yaml.load(self.Yaml, Loader=yaml.FullLoader)
 
     def get_param(self, param: str) -> any:

--- a/dal/models/configuration.py
+++ b/dal/models/configuration.py
@@ -37,7 +37,6 @@ class Configuration(Model):
         if self.Type == "xml":
             # Yaml is the name of the field
             return self.Yaml
-        
         # Don't need to go to DB because the schema is already loaded in the constructor of the class
         # TODO:We can implement a proper caching system later to save this yaml.load operation
         return yaml.load(self.Yaml, Loader=yaml.FullLoader)

--- a/dal/models/configuration.py
+++ b/dal/models/configuration.py
@@ -37,7 +37,7 @@ class Configuration(Model):
         if self.Type == "xml":
             # Yaml is the name of the field
             return self.Yaml
-        # Don't need to go to DB because the schema is already loaded in the constructor of the class
+        # Don't need to go to DB, the schema is already loaded in the constructor of the class
         # TODO:We can implement a proper caching system later to save this yaml.load operation
         return yaml.load(self.Yaml, Loader=yaml.FullLoader)
 


### PR DESCRIPTION
There was an attempt to improve the performance of the yaml.load function by implementing a cache [here](https://github.com/MOV-AI/movai_classes/commit/579f89e9e4ed3fe0fe729708bdb5226d07dd1c58#diff-7acde07cc5cff3653fa6e2e554a2f1abfb70aca5872dcc01328bad253b0b8e7c)

[BP-1195](https://movai.atlassian.net/browse/BP-1195): The cache wasn't working properly because it allowed external entities to edit the cached dictionary - use case of overwritten annotations - and then every time you wanted to access the same configuration you would get the cached dictionary and not the one in the DB. This way didn't save from reading from the DB either, it was actually reading 2 times from the DB lol.

So for now, will remove this caching way and the unnecessary read of DB.


[BP-1195]: https://movai.atlassian.net/browse/BP-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ