### PR TITLE
Redis mocking tool

### DIFF
--- a/dal/classes/utils/secretkey.py
+++ b/dal/classes/utils/secretkey.py
@@ -22,7 +22,6 @@ class SecretKey:
     secret_key_dict = {"KeyLength": "", "Secret": "", "LastUpdate": ""}
 
     @classmethod
-    @property
     def db(cls):
         if cls._db is None:
             cls._db = MovaiDB(db="global")
@@ -54,7 +53,7 @@ class SecretKey:
         Returns:
             bool: True if exist, False otherwise.
         """
-        secret = cls.db.get_value({cls.type_name: {fleet_name: {"Secret": ""}}})
+        secret = cls.db().get_value({cls.type_name: {fleet_name: {"Secret": ""}}})
         return secret is not None
 
     @classmethod
@@ -71,7 +70,7 @@ class SecretKey:
         if cls.is_exist(fleet_name):
             error_msg = f"The secret key {fleet_name} already exist."
             raise SecretKeyAlreadyExist(error_msg)
-        cls.db.set({cls.type_name: {fleet_name: cls._generate_dict(length)}})
+        cls.db().set({cls.type_name: {fleet_name: cls._generate_dict(length)}})
 
     @classmethod
     def remove(cls, fleet_name: str) -> None:
@@ -87,7 +86,7 @@ class SecretKey:
             error_msg = f"The secret key {fleet_name} does not exist."
             cls.log.error(error_msg)
             raise SecretKeyDoesNotExist(error_msg)
-        cls.db.delete({cls.type_name: {fleet_name: cls.secret_key_dict}})
+        cls.db().delete({cls.type_name: {fleet_name: cls.secret_key_dict}})
 
     @classmethod
     def update(cls, fleet_name: str, length: int = 32) -> None:
@@ -104,7 +103,7 @@ class SecretKey:
             error_msg = f"The secret key {fleet_name} does not exist."
             cls.log.error(error_msg)
             raise SecretKeyDoesNotExist(error_msg)
-        cls.db.set({cls.type_name: {fleet_name: cls._generate_dict(length)}})
+        cls.db().set({cls.type_name: {fleet_name: cls._generate_dict(length)}})
 
     @classmethod
     def get_secret(cls, fleet_name: str) -> str:
@@ -120,5 +119,5 @@ class SecretKey:
             error_msg = f"The secret key {fleet_name} does not exist."
             cls.log.error(error_msg)
             raise SecretKeyDoesNotExist(error_msg)
-        secret = cls.db.get_value({cls.type_name: {fleet_name: {"Secret": ""}}})
+        secret = cls.db().get_value({cls.type_name: {fleet_name: {"Secret": ""}}})
         return secret

--- a/dal/classes/utils/secretkey.py
+++ b/dal/classes/utils/secretkey.py
@@ -19,11 +19,18 @@ from dal.movaidb import MovaiDB
 
 class SecretKey:
     log = Log.get_logger(__name__)
-    db = MovaiDB(db='global')
+    _db = None
     type_name = 'SecretKey'
     secret_key_dict = {'KeyLength': '',
                        'Secret': '',
                        'LastUpdate': ''}
+
+    @classmethod
+    @property
+    def db(cls):
+        if cls._db is None:
+            cls._db = MovaiDB(db='global')
+        return cls._db
 
     @classmethod
     def _generate_dict(cls, length: int) -> dict:

--- a/dal/classes/utils/secretkey.py
+++ b/dal/classes/utils/secretkey.py
@@ -6,13 +6,11 @@
    Developers:
    - Erez Zomer  (erez@mov.ai) - 2022
 """
+
 from movai_core_shared.logger import Log
 from movai_core_shared.common.time import current_time_string
 from movai_core_shared.core.secure import generate_secret_string
-from movai_core_shared.exceptions import (
-    SecretKeyAlreadyExist,
-    SecretKeyDoesNotExist
-)
+from movai_core_shared.exceptions import SecretKeyAlreadyExist, SecretKeyDoesNotExist
 
 from dal.movaidb import MovaiDB
 
@@ -20,16 +18,14 @@ from dal.movaidb import MovaiDB
 class SecretKey:
     log = Log.get_logger(__name__)
     _db = None
-    type_name = 'SecretKey'
-    secret_key_dict = {'KeyLength': '',
-                       'Secret': '',
-                       'LastUpdate': ''}
+    type_name = "SecretKey"
+    secret_key_dict = {"KeyLength": "", "Secret": "", "LastUpdate": ""}
 
     @classmethod
     @property
     def db(cls):
         if cls._db is None:
-            cls._db = MovaiDB(db='global')
+            cls._db = MovaiDB(db="global")
         return cls._db
 
     @classmethod
@@ -43,9 +39,9 @@ class SecretKey:
         Returns:
             dict: The created dictionary.
         """
-        cls.secret_key_dict['KeyLength'] = length
-        cls.secret_key_dict['Secret'] = generate_secret_string(length)
-        cls.secret_key_dict['LastUpdate'] = current_time_string()
+        cls.secret_key_dict["KeyLength"] = length
+        cls.secret_key_dict["Secret"] = generate_secret_string(length)
+        cls.secret_key_dict["LastUpdate"] = current_time_string()
         return cls.secret_key_dict
 
     @classmethod
@@ -58,7 +54,7 @@ class SecretKey:
         Returns:
             bool: True if exist, False otherwise.
         """
-        secret = cls.db.get_value({cls.type_name: {fleet_name: {'Secret': ''}}})
+        secret = cls.db.get_value({cls.type_name: {fleet_name: {"Secret": ""}}})
         return secret is not None
 
     @classmethod
@@ -66,7 +62,7 @@ class SecretKey:
         """creates a new key in the DB
 
         Args:
-            fleet_name (str): The name of the fleet which owns the key. 
+            fleet_name (str): The name of the fleet which owns the key.
             length (int, optional): The length of the key.. Defaults to 32.
 
         Returns:
@@ -82,7 +78,7 @@ class SecretKey:
         """Removes a key from the DB.
 
         Args:
-            fleet_name (str): The name of the fleet which owns the key. 
+            fleet_name (str): The name of the fleet which owns the key.
 
         Returns:
             bool: True if succesfull, False otherwise.
@@ -98,7 +94,7 @@ class SecretKey:
         """updates an existing key in the DB.
 
         Args:
-            fleet_name (str): The name of the fleet which owns the key. 
+            fleet_name (str): The name of the fleet which owns the key.
             length (int, optional): The length of the key.. Defaults to 32.
 
         Returns:
@@ -124,5 +120,5 @@ class SecretKey:
             error_msg = f"The secret key {fleet_name} does not exist."
             cls.log.error(error_msg)
             raise SecretKeyDoesNotExist(error_msg)
-        secret = cls.db.get_value({cls.type_name: {fleet_name: {'Secret': ''}}})
+        secret = cls.db.get_value({cls.type_name: {fleet_name: {"Secret": ""}}})
         return secret

--- a/dal/classes/utils/token.py
+++ b/dal/classes/utils/token.py
@@ -97,8 +97,15 @@ class TokenManager:
     """A general class for managing tokens in DB."""
 
     log = Log.get_logger('TokenManger')
-    db = MovaiDB(db="local")
+    _db = None
     token_type = "Token"
+
+    @classmethod
+    @property
+    def db(cls):
+        if cls._db is None:
+            cls._db = MovaiDB(db="local")
+        return cls._db
 
     @classmethod
     def is_token_exist(cls, token_id: str) -> bool:

--- a/dal/classes/utils/token.py
+++ b/dal/classes/utils/token.py
@@ -6,6 +6,7 @@
    Developers:
    - Erez Zomer  (erez@mov.ai) - 2022
 """
+
 from socket import gethostname
 import uuid
 import jwt
@@ -96,7 +97,7 @@ class EmptyDBToken(dict):
 class TokenManager:
     """A general class for managing tokens in DB."""
 
-    log = Log.get_logger('TokenManger')
+    log = Log.get_logger("TokenManger")
     _db = None
     token_type = "Token"
 
@@ -129,9 +130,7 @@ class TokenManager:
         """
         if cls.is_token_exist(token_id):
             cls.db.delete(EmptyDBToken(token_id))
-            cls.log.debug(
-                f"The token id {token_id} has been removed from the allowed token list."
-            )
+            cls.log.debug(f"The token id {token_id} has been removed from the allowed token list.")
 
     @classmethod
     def store_token(cls, token: TokenObject) -> None:
@@ -141,14 +140,11 @@ class TokenManager:
             token (TokenObject): The token to store.
         """
         cls.db.set(DBToken(token))
-        cls.log.debug(
-            f"The token id {token.jwt_id} has been added to the allowed token list."
-        )
+        cls.log.debug(f"The token id {token.jwt_id} has been added to the allowed token list.")
 
     @classmethod
     def remove_all_tokens(cls):
-        """Removes all token from db.
-        """
+        """Removes all token from db."""
         cls.log.info(f"Removing all tokens from token list.")
         tokens = cls.db.get(EmptyDBToken(None, cls.token_type))
         tokens = tokens.get(cls.token_type)
@@ -170,10 +166,11 @@ class TokenManager:
                 if token_data["ExpirationTime"] < current_time:
                     cls.remove_token(token_id)
 
+
 class Token:
     allowed_algorithms = ["HS256", "RS256", "ES256"]
     required_keys = set(["sub", "iss", "iat", "exp", "jti"])
-    log = Log.get_logger('Token')
+    log = Log.get_logger("Token")
     _token_manager = TokenManager
     _issuer = gethostname()
 

--- a/dal/classes/utils/token.py
+++ b/dal/classes/utils/token.py
@@ -102,7 +102,6 @@ class TokenManager:
     token_type = "Token"
 
     @classmethod
-    @property
     def db(cls):
         if cls._db is None:
             cls._db = MovaiDB(db="local")
@@ -118,7 +117,7 @@ class TokenManager:
         Returns:
             bool: True if exist, False otherwise.
         """
-        result = cls.db.get(EmptyDBToken(token_id))
+        result = cls.db().get(EmptyDBToken(token_id))
         return len(result.keys()) > 0
 
     @classmethod
@@ -129,7 +128,7 @@ class TokenManager:
             token (TokenObject): The token to remove.
         """
         if cls.is_token_exist(token_id):
-            cls.db.delete(EmptyDBToken(token_id))
+            cls.db().delete(EmptyDBToken(token_id))
             cls.log.debug(f"The token id {token_id} has been removed from the allowed token list.")
 
     @classmethod
@@ -139,14 +138,14 @@ class TokenManager:
         Args:
             token (TokenObject): The token to store.
         """
-        cls.db.set(DBToken(token))
+        cls.db().set(DBToken(token))
         cls.log.debug(f"The token id {token.jwt_id} has been added to the allowed token list.")
 
     @classmethod
     def remove_all_tokens(cls):
         """Removes all token from db."""
         cls.log.info(f"Removing all tokens from token list.")
-        tokens = cls.db.get(EmptyDBToken(None, cls.token_type))
+        tokens = cls.db().get(EmptyDBToken(None, cls.token_type))
         tokens = tokens.get(cls.token_type)
         if tokens is not None:
             for token_id in tokens.keys():
@@ -158,7 +157,7 @@ class TokenManager:
         time has passed.
         """
         cls.log.info(f"Removing all expired tokens.")
-        tokens = cls.db.get(EmptyDBToken(None, cls.token_type))
+        tokens = cls.db().get(EmptyDBToken(None, cls.token_type))
         tokens = tokens.get(cls.token_type)
         current_time = current_timestamp_int()
         if tokens is not None:

--- a/dal/movaidb/database.py
+++ b/dal/movaidb/database.py
@@ -19,6 +19,7 @@ import pickle
 import aioredis
 from deepdiff import DeepDiff
 from redis.client import Pipeline
+from redis.connection import Connection
 
 import dal
 from movai_core_shared.logger import Log
@@ -166,11 +167,11 @@ class AioRedisClient(metaclass=Singleton):
                         address = (conn_config["host"], conn_config["port"])
                         if conn_config.get("mode") == "SUB":
                             _conn = await aioredis.create_pool(
-                                address, minsize=1, maxsize=100
+                                address, minsize=1, maxsize=100, pool_cls=aioredis.ConnectionsPool
                             )
                         else:
                             _conn = await aioredis.create_redis_pool(
-                                address, minsize=2, maxsize=100, timeout=1
+                                address, minsize=2, maxsize=100, timeout=1, pool_cls=aioredis.ConnectionsPool
                             )
                     except Exception as e:
                         LOGGER.error(e)
@@ -194,12 +195,15 @@ class Redis(metaclass=Singleton):
 
     def __init__(self):
         self.master_pool = redis.ConnectionPool(
+            connection_class=Connection,
             host=MovaiDB.REDIS_MASTER_HOST, port=MovaiDB.REDIS_MASTER_PORT, db=0
         )
         self.slave_pool = redis.ConnectionPool(
+            connection_class=Connection,
             host=MovaiDB.REDIS_SLAVE_HOST, port=MovaiDB.REDIS_SLAVE_PORT, db=0
         )
         self.local_pool = redis.ConnectionPool(
+            connection_class=Connection,
             host=MovaiDB.REDIS_LOCAL_HOST, port=MovaiDB.REDIS_LOCAL_PORT, db=0
         )
 
@@ -334,7 +338,6 @@ class MovaiDB:
         loop: Optional[asyncio.AbstractEventLoop] = None,
         databases=None,
     ) -> None:
-
         self.movaidb = databases or Redis()
         for attribute, val in self.db_dict[db].items():
             setattr(self, attribute, getattr(self.movaidb, val))

--- a/dal/plugins/persistence/redis/redis.py
+++ b/dal/plugins/persistence/redis/redis.py
@@ -49,7 +49,7 @@ class RedisPlugin(PersistencePlugin):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._REDIS_MASTER_POOL = ConnectionPool(
-            host=self._REDIS_MASTER_HOST, port=self._REDIS_MASTER_PORT, db=0, connection_class=Connection),
+            host=self._REDIS_MASTER_HOST, port=self._REDIS_MASTER_PORT, db=0, connection_class=Connection)
         self._REDIS_SLAVE_POOL = ConnectionPool(
             host=self._REDIS_SLAVE_HOST, port=self._REDIS_SLAVE_PORT, db=0, connection_class=Connection)
 
@@ -651,7 +651,7 @@ class RedisPlugin(PersistencePlugin):
 
         The data part must comply with the schema of the scope
         """
-        conn = Redis(connection_pool=RedisPlugin._REDIS_MASTER_POOL)
+        conn = Redis(connection_pool=self._REDIS_MASTER_POOL)
 
         if issubclass(type(data), ScopeInstanceVersionNode):
 

--- a/dal/plugins/persistence/redis/redis.py
+++ b/dal/plugins/persistence/redis/redis.py
@@ -13,6 +13,7 @@ import json
 import fnmatch
 from redis.client import ConnectionPool, Redis
 from redis.exceptions import ResponseError
+from redis.connection import Connection
 
 from dal.plugins.classes import Plugin, Persistence, PersistencePlugin
 from dal.data import (
@@ -45,10 +46,12 @@ class RedisPlugin(PersistencePlugin):
     _REDIS_SLAVE_HOST = MovaiDB.REDIS_SLAVE_HOST
     _REDIS_SLAVE_PORT = MovaiDB.REDIS_SLAVE_PORT
 
-    _REDIS_MASTER_POOL = ConnectionPool(
-        host=_REDIS_MASTER_HOST, port=_REDIS_MASTER_PORT, db=0)
-    _REDIS_SLAVE_POOL = ConnectionPool(
-        host=_REDIS_SLAVE_HOST, port=_REDIS_SLAVE_PORT, db=0)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._REDIS_MASTER_POOL = ConnectionPool(
+            host=self._REDIS_MASTER_HOST, port=self._REDIS_MASTER_PORT, db=0, connection_class=Connection),
+        self._REDIS_SLAVE_POOL = ConnectionPool(
+            host=self._REDIS_SLAVE_HOST, port=self._REDIS_SLAVE_PORT, db=0, connection_class=Connection)
 
     def decode_value(self, _value):
         '''Decodes a value from redis'''
@@ -410,7 +413,7 @@ class RedisPlugin(PersistencePlugin):
         to use a "caching" mechanism, probably a set that is updated
         everytime a a scope is added/delete
         """
-        conn = Redis(connection_pool=RedisPlugin._REDIS_SLAVE_POOL)
+        conn = Redis(connection_pool=self._REDIS_SLAVE_POOL)
         scopes = []
         processed = set()
         scope = kwargs.get("scope", "*")
@@ -497,7 +500,7 @@ class RedisPlugin(PersistencePlugin):
         """
         list all existing scopes
         """
-        conn = Redis(connection_pool=RedisPlugin._REDIS_SLAVE_POOL)
+        conn = Redis(connection_pool=self._REDIS_SLAVE_POOL)
         try:
             scope = kwargs["scope"]
             ref = kwargs["ref"]
@@ -543,7 +546,7 @@ class RedisPlugin(PersistencePlugin):
                 raise ValueError("missing scope,ref,version or model") from e
 
         # We are reading so we connect to the slave instance
-        conn = Redis(connection_pool=RedisPlugin._REDIS_SLAVE_POOL)
+        conn = Redis(connection_pool=self._REDIS_SLAVE_POOL)
         out = set()
 
         # We first check if we have cached relations ( see rebuild_indexes )
@@ -759,7 +762,7 @@ class RedisPlugin(PersistencePlugin):
         except KeyError as e:
             raise ValueError("missing scope or name") from e
 
-        conn = Redis(connection_pool=RedisPlugin._REDIS_SLAVE_POOL)
+        conn = Redis(connection_pool=self._REDIS_SLAVE_POOL)
 
         try:
             schema_version = kwargs["schema_version"]

--- a/dal/utils/redis_mocks.py
+++ b/dal/utils/redis_mocks.py
@@ -1,0 +1,178 @@
+import asyncio
+import logging
+import os
+import pickle
+from fnmatch import fnmatch
+from typing import Any, Callable, Dict, List, Optional, Type
+from unittest.mock import _patch, _get_target
+
+import redis
+import aioredis
+
+
+### Set to True if you want to record real interactions with Redis
+### Set to False to mock Redis using pre-saved interactions
+RECORD = True
+
+
+logger = logging.getLogger("RedisProxies")
+
+
+RECEIVER_LOOP: List[asyncio.AbstractEventLoop] = []
+CHANNELS: Dict[bytes, aioredis.Channel] = {}
+
+class _fake_redis(_patch):
+    recording_dir: str
+
+    @staticmethod
+    def make_connection_class(recording_path: str) -> Type:
+        class FakeConnection(redis.connection.Connection):
+            """ Implements a VCRpy style mock, which can record real connections 
+                to Redis and save them to a file. Then that file can be used 
+                to reproduce communications without needing Redis """
+            
+            __responses = {}
+            __last_out: List[Optional[str]] = [None]
+
+            def __init__(self, host, port, db=0, **kwargs):
+                if not RECORD:
+                    with open(recording_path, "rb") as f:
+                        FakeConnection.__responses = pickle.load(f)
+                super().__init__(host=host, port=port, db=db, **kwargs)
+
+            def connect(self):
+                if RECORD:
+                    super().connect()
+                else:
+                    self.on_connect()
+
+            def can_read(self, timeout: float | None = 0) -> bool:
+                return super().can_read(timeout=timeout) if RECORD else False
+            
+            def send_command(self, *args, **kwargs) -> None:
+                FakeConnection.__last_out[0] = f"({args}, {kwargs})"
+                logger.info("send_command(%s, %s)", args, kwargs)
+                if RECORD:
+                    super().send_command(*args, **kwargs)
+                elif args[0] == "PUBLISH":
+                    loop = RECEIVER_LOOP[0]
+                    channel_name, msg = args[1], args[2]
+                    for pattern, channel in CHANNELS.items():
+                        pattern_str = pattern.decode("utf-8")
+                        if fnmatch(channel_name, pattern_str):
+                            logger.warning("Publishing %s %s to %s(%s) on loop %s", pattern, msg, channel, id(channel), loop)
+                            loop.call_soon_threadsafe(
+                                (lambda channel, pattern, msg: channel.put_nowait((pattern, msg.encode("utf-8")))),
+                                channel, pattern, msg)
+            
+            def read_response(self, disable_decoding: bool = False, *, disconnect_on_error: bool = True):
+                logger.warning("read_response()")
+                if RECORD:
+                    try:
+                        value = super().read_response(disable_decoding, disconnect_on_error=disconnect_on_error)
+                    except Exception as e:
+                        logger.warning("GOT EXC: %s", e)
+                        value = e
+
+                    FakeConnection.__responses[FakeConnection.__last_out[0]] = value
+                    with open(recording_path, "wb") as f:
+                        pickle.dump(FakeConnection.__responses, f)
+                    logger.warning("returning %s", value)
+                else:
+                    value = FakeConnection.__responses[FakeConnection.__last_out[0]]
+
+                if isinstance(value, Exception):
+                    raise value
+                else:
+                    return value
+
+            
+            def disconnect(self, *args: object) -> None:
+                if RECORD:
+                    super().disconnect(*args)
+        return FakeConnection
+        
+
+    def __init__(self: _patch, getter: Callable[[], Any], attribute: str, recording_dir) -> None:
+        super().__init__(getter, attribute, new=None, spec=None, create=False, spec_set=None,
+                         autospec=None, new_callable=None, kwargs={})
+        self.recording_dir = recording_dir
+
+    def __call__(self, func: Callable) -> Callable:
+        recording_path = os.path.join(self.recording_dir, f"{func.__name__}.pickle")
+        self.new = self.make_connection_class(recording_path)
+        return super().__call__(func)
+
+
+def fake_redis(target, recording_dir):
+    # copied from unittest.mock.patch()
+    getter, attribute = _get_target(target)
+    return _fake_redis(getter, attribute, recording_dir=recording_dir)
+
+
+class FakeAsyncConnection(aioredis.connection.AbcConnection):
+    """ Basic mock connection that allows subscribing to a channel pattern (psubscribe) """
+
+    def __init__(self, reader, writer, *, address, encoding=None, parser=None, loop=None):
+        self._pubsub_channels = CHANNELS
+
+    def close(self):
+        return
+
+    async def wait_closed(self):
+        return
+
+    def execute_pubsub(self, command, *channels):
+        channels = [aioredis.Channel(ch, is_pattern=True) for ch in channels]
+        for channel in channels:
+            self._pubsub_channels[channel.name] = channel
+        logger.warning("Subscribe to channels %s", self._pubsub_channels)
+        loop = asyncio.get_running_loop()
+        if len(RECEIVER_LOOP) == 0:
+            RECEIVER_LOOP.append(loop)
+        fut = loop.create_future()
+        fut.set_result([(None, channel.name, None) for channel in channels])
+        return fut
+    
+    def execute(self, command, *args, encoding=...):
+        fut = asyncio.get_running_loop().create_future()
+        fut.set_result(True)
+        return fut
+    
+    @property
+    def closed(self):
+        return False
+    
+    @property
+    def db(self):
+        return 0
+    
+    @property
+    def encoding(self):
+        return None
+    
+    @property
+    def address(self):
+        return "fakehost"
+    
+    @property
+    def in_pubsub(self):
+        return True
+    
+    @property
+    def pubsub_channels(self):
+        return {}
+    
+    @property
+    def pubsub_patterns(self):
+        return CHANNELS
+
+
+class FakeAsyncPool(aioredis.ConnectionsPool):
+    def _create_new_connection(self, address):
+        if RECORD:
+            return super()._create_new_connection(address)
+        else:
+            fut = asyncio.get_running_loop().create_future()
+            fut.set_result(FakeAsyncConnection(None, None, address=address))
+            return fut


### PR DESCRIPTION
Adds some classes that allow mocking Redis communications. There are two classes:

- FakeAsyncConnection is only used for mocking PUB/SUB messages, specifically the subscription part. It'll open a (local) channel and allow waiting for new messages.
- FakeConnection has two features:
  1) Recording and playback of Redis communications, inspired by VCRpy. You set RECORDING=True and then run the test once on a robot with Redis running. It'll monitor the commands and responses to and from Redis, and record them in a pickle file. Afterwards, you can set RECORDING=False, and run the test again: the mock will return the recorded responses that Redis would have sent, without having to actually run Redis.
  2) Support for mocking PUB/SUB messages, specifically the publishing part. It communicates with FakeAsyncConnection, allowing for messages to be sent to those channels.

Part of the work for [BP-944](https://movai.atlassian.net/browse/BP-944)

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[BP-944]: https://movai.atlassian.net/browse/BP-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ