### PR TITLE
Update redissub.py

### DIFF
--- a/dal/classes/protocols/redissub.py
+++ b/dal/classes/protocols/redissub.py
@@ -55,8 +55,13 @@ class Var_Subscriber(gdnode_modules["BaseIport"]):
             raise Exception(
                 "'" + var_type + "' is not a valid scope. Choose between: " + str(scopes)[1:-1])
 
-        prefixes = {'node': _node_name + '@', 'robot': '@',
-                    'fleet': Robot().name + '@', 'global': '@', 'flow': 'flow@'}
+        prefixes = {
+            "node": _node_name + "@",
+            "robot": "@",
+            "fleet": Robot().RobotName + "@",
+            "global": "@",
+            "flow": "flow@",
+        }
 
         prefix = prefixes.get(var_type, '@')
 


### PR DESCRIPTION
Fixed a bug where the redis key for fleet variables was using the robot_id instead of the robot name.
