### PR TITLE
Missing renaming for DP-1504

### DIFF
--- a/dal/scopes/fleetrobot.py
+++ b/dal/scopes/fleetrobot.py
@@ -93,7 +93,7 @@ class FleetRobot(Scope):
 
         if hasattr(self, "spawner_client") and self.spawner_client is not None:
             res = self.spawner_client.send_request(
-                COMMAND_HANDLER_MSG_TYPE, req_data, respose_required=response_required
+                COMMAND_HANDLER_MSG_TYPE, req_data, response_required=response_required
             )
             if (not response_required) or (
                 response_required


### PR DESCRIPTION
DP-1504 is a review of ZMQClient classes in movai-core-shared, this has impact on send_request() prototype which was using a badly written `respose_required` parameter.

This is catch by QA platform tests:
```
FAILED test_platform_tests.py::test_tc_23_test_that_a_flow_parameter_arrives_to_a_gd_node_inside_a_sub_flow - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_platform_tests.py::test_tc_16_test_runtime_parsed_params_fleet_var - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_platform_tests.py::test_tc_14_test_runtime_parsed_params_flow_var - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_platform_tests.py::test_tc_17_test_runtime_parsed_params_global_var - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_platform_tests.py::test_tc_12_test_that_a_parameter_arrives_to_a_gd_node_coming_from_a_flow - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_platform_tests.py::test_tc_22_test_that_a_boolean_parameter_arrives_to_a_gd_node_coming_from_a_flow - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_platform_tests.py::test_tc_02_test_that_a_parameter_arrives_to_a_gd_node_from_a_node_instance - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_platform_tests.py::test_tc_01_test_that_a_parameter_arrives_to_a_gd_node_from_the_node_template - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_platform_tests.py::test_tc_15_test_runtime_parsed_params_robot_var - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_platform_tests.py::test_tc_18_test_runtime_parsed_params_from_configuration_file - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_platform_tests.py::test_tc_24_test_subscription_to_fleet_var - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_protocol.py::test_protocol_context_issue - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_scene.py::test_overwrite_traj_annotation_val_in_scene - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_topic_properties.py::test_topic_latch - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_transitions.py::test_node_loop - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
FAILED test_transitions.py::test_persistent_gd_node - RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['S...
```

With the following stack:
```
test_transitions.py:53: in test_persistent_gd_node
    with Flow(movai_properties, robot_properties, test_flow) as flow_run:
.venv/lib/python3.11/site-packages/flows_test_core/flow.py:169: in __enter__
    self._flow_execution("START")
.venv/lib/python3.11/site-packages/flows_test_core/flow.py:96: in _flow_execution
    self.__call_post_ide(data)
.venv/lib/python3.11/site-packages/flows_test_core/flow.py:75: in __call_post_ide
    raise RuntimeError(
E   RuntimeError: Failed POST https://localhost:443/api/v1/frontend/ide/ with {'func': 'sendToRobot', 'args': ['START', 'test_persistent_gd_node', '7d77f504f69149a1880aadf6699535e2']}: 200, {"success": false, "error": "send_request() got an unexpected keyword argument 'respose_required'"}
```


- [ ] Make sure you are opening from a **topic/feature/bugfix branch**
- [ ] Ensure that the PR title represents the desired changes
- [ ] Ensure that the PR description detail the desired changes
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

