### PR TITLE
Revert CallbackSubscription class

### DIFF
--- a/.github/workflows/TestOnPR.yml
+++ b/.github/workflows/TestOnPR.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Download generated python artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: packages
           path: dist

--- a/dal/classes/protocols/redis.py
+++ b/dal/classes/protocols/redis.py
@@ -8,19 +8,15 @@
 
    Redis related protocols to be used in new Mov-Node
 """
-
 import asyncio
-from typing import Callable
 from dal.movaidb import MovaiDB
-from dal.movaidb.database import CallbackSubscription
 
 
 class ContextMsg:
     """Message for Context
-    data -> dictionary of full context table
-    changed -> dictionary only of values changed
+        data -> dictionary of full context table
+        changed -> dictionary only of values changed
     """
-
     def __init__(self, id={}, data={}, changed={}):
         self.data = data
         self.changed = changed
@@ -34,15 +30,14 @@ class ContextProtocolIn:
         self._callback = callback
         self.stack = params.get('Namespace', '')
         self.loop = asyncio.get_event_loop()
+        self.loop.create_task(self.register_sub())
 
-    async def register_sub(self) -> CallbackSubscription:
-        """Subscribe to key asynchronously
-
-        Returns a Task that indicates when it's subscribed"""
-        pattern = {"Var": {"context": {"ID": {self.ID: {"Parameter": "**"}}}}}
+    async def register_sub(self) -> None:
+        """Subscribe to key."""
+        pattern = {'Var': {'context': {'ID': {self.ID: {'Parameter': '**'}}}}}
         databases = await MovaiDB.AioRedisClient.get_client()
-        movaidb = MovaiDB("local", loop=self.loop, databases=databases)
-        return await movaidb.subscribe_channel(pattern, self.callback_wrapper)
+        await MovaiDB('local', loop=self.loop, databases=databases).\
+            subscribe_channel(pattern, self.callback_wrapper)
 
     def callback_wrapper(self, msg):
         """Executes callback"""

--- a/dal/classes/protocols/redis.py
+++ b/dal/classes/protocols/redis.py
@@ -82,7 +82,7 @@ class ContextServerIn(ContextProtocolIn):
         ContextProtocolIn (_type_): _description_
     """
     def __init__(self, callback: Callable, params: dict, **kwargs) -> None:
-        super().__init__(callback, params, **kwargs)
+        super().__init__(call   back, params, **kwargs)
 
     @property
     def ID(self) -> str:

--- a/dal/classes/protocols/redis.py
+++ b/dal/classes/protocols/redis.py
@@ -29,8 +29,6 @@ class ContextMsg:
 
 
 class ContextProtocolIn:
-    """Subscribes to context channels and runs a callback when the ID is mentioned"""
-
     ID: str
 
     def __init__(self, callback: Callable, params: dict, **ignore) -> None:

--- a/dal/classes/protocols/redis.py
+++ b/dal/classes/protocols/redis.py
@@ -11,7 +11,6 @@
 
 import asyncio
 from typing import Callable
-
 from dal.movaidb import MovaiDB
 from dal.movaidb.database import CallbackSubscription
 
@@ -29,9 +28,9 @@ class ContextMsg:
 
 
 class ContextProtocolIn:
-    ID: str
-
-    def __init__(self, callback: Callable, params: dict, **ignore) -> None:
+    """_summary_
+    """
+    def __init__(self, callback: callable, params: dict, **ignore) -> None:
         self._callback = callback
         self.stack = params.get('Namespace', '')
         self.loop = asyncio.get_event_loop()
@@ -67,11 +66,11 @@ class ContextClientIn(ContextProtocolIn):
     Args:
         ContextProtocolIn (_type_): _description_
     """
-    def __init__(self, callback: Callable, params: dict, **kwargs) -> None:
+    def __init__(self, callback: callable, params: dict, **kwargs) -> None:
         super().__init__(callback, params, **kwargs)
 
     @property
-    def ID(self) -> str:
+    def ID(self):
         return self.stack + "_TX"
 
 
@@ -81,11 +80,11 @@ class ContextServerIn(ContextProtocolIn):
     Args:
         ContextProtocolIn (_type_): _description_
     """
-    def __init__(self, callback: Callable, params: dict, **kwargs) -> None:
-        super().__init__(call   back, params, **kwargs)
+    def __init__(self, callback: callable, params: dict, **kwargs) -> None:
+        super().__init__(callback, params, **kwargs)
 
     @property
-    def ID(self) -> str:
+    def ID(self):
         return self.stack + "_RX"
 
 

--- a/dal/movaidb/database.py
+++ b/dal/movaidb/database.py
@@ -12,15 +12,13 @@
 import asyncio
 from os import getenv, path
 from re import split
-from typing import Any, Callable, Optional, Tuple, cast
-
 import redis
+from deepdiff import DeepDiff
 import pickle
 import aioredis
-from deepdiff import DeepDiff
 from redis.client import Pipeline
 from redis.connection import Connection
-
+from typing import Any, Callable, Dict, Generator, Optional, Tuple, List, Union, cast
 import dal
 from movai_core_shared.logger import Log
 from movai_core_shared.exceptions import InvalidStructure
@@ -36,7 +34,6 @@ __SCHEMAS_URL__ = f"file://{dal_directory}/validation/schema"
 
 
 class CallbackSubscription:
-    """ Provides mechanisms to control the subscription to Redis channels """
     conn: Optional[aioredis.Redis] = None
     channel: Optional[aioredis.Channel] = None
 
@@ -77,7 +74,6 @@ class CallbackSubscription:
         await self.conn.wait_closed()
 
     def unsubscribe(self):
-        """ Unsubscribe from Redis channel """
         if self.channel and self.conn:
             self.conn.punsubscribe(self.channel)
             self.channel = None

--- a/dal/movaidb/database.py
+++ b/dal/movaidb/database.py
@@ -32,51 +32,22 @@ LOGGER = Log.get_logger("dal.mov.ai")
 dal_directory = path.dirname(dal.__file__)
 __SCHEMAS_URL__ = f"file://{dal_directory}/validation/schema"
 
+class SubscribeManager(metaclass=Singleton):
+   
+    _key_map={}
 
-class CallbackSubscription:
-    conn: Optional[aioredis.Redis] = None
-    channel: Optional[aioredis.Channel] = None
+    @classmethod
+    def register_sub(cls, key):
+        cls._key_map[key] = None
 
-    def __init__(self, pubsub, key: str, callback: Callable):
-        self.pubsub = pubsub
-        self.key = key
-        self.callback = callback
+    @classmethod
+    def unregister_sub(cls, key):
+        del cls._key_map[key]
+    
+    @classmethod    
+    def is_registered(cls, key):
+        return key in cls._key_map
 
-    async def subscribe(self) -> asyncio.Event:
-        """Start listening to messages and call callback when it receives one
-
-        returns Event that notifies when the subscription is ready
-        """
-        subscription_event = asyncio.Event()
-        asyncio.get_running_loop().create_task(self._run(subscription_event))
-        return subscription_event
-
-    async def _run(self, evt: asyncio.Event):
-        # Acquires a connection from free pool.
-        # Creates new connection if needed.
-        _conn = await self.pubsub.acquire()
-        # Create Redis interface
-        self.conn = aioredis.Redis(_conn)
-        # Switch connection to Pub/Sub mode and subscribe to specified patterns
-        # we use cast() just to help the type checker, it doesn't change anything
-        self.channel = cast(aioredis.Channel, (await self.conn.psubscribe(self.key))[0])
-        # Inform subscription is ready
-        evt.set()
-
-        LOGGER.warning("Waiting")
-
-        # Waits for message to become available in channel
-        while await self.channel.wait_message():
-            msg = await self.channel.get(encoding="utf-8")
-            self.callback(msg)
-
-        self.conn.close()
-        await self.conn.wait_closed()
-
-    def unsubscribe(self):
-        if self.channel and self.conn:
-            self.conn.punsubscribe(self.channel)
-            self.channel = None
 
 
 class AioRedisClient(metaclass=Singleton):
@@ -232,19 +203,12 @@ class Redis(metaclass=Singleton):
     def slave_pubsub(self) -> redis.client.PubSub:
         return self.db_slave.pubsub()
 
-    @property
     def local_pubsub(self) -> redis.client.PubSub:
         return self.db_local.pubsub()
 
 
 class MovaiDB:
     """Main MovaiDB"""
-
-    loop: asyncio.AbstractEventLoop
-    movaidb: Redis
-    db_read: redis.Redis
-    db_write: redis.Redis
-    pubsub: redis.client.PubSub
 
     class API(dict):
         """
@@ -342,9 +306,13 @@ class MovaiDB:
         db: str = "global",
         _api_version: str = "latest",
         *,
-        loop: Optional[asyncio.AbstractEventLoop] = None,
+        loop=None,
         databases=None,
     ) -> None:
+        self.db_read: redis.Redis = None
+        self.db_write: redis.Redis = None
+        self.pubsub: redis.client.PubSub = None
+
         self.movaidb = databases or Redis()
         for attribute, val in self.db_dict[db].items():
             setattr(self, attribute, getattr(self.movaidb, val))
@@ -359,9 +327,8 @@ class MovaiDB:
         self.api_star = self.template_to_star(self.api_struct)
         # self.validator = Validator(db).val
 
-        if loop:
-            self.loop = loop
-        else:
+        self.loop = loop
+        if not self.loop:
             try:
                 self.loop = asyncio.get_event_loop()
             except Exception:
@@ -603,22 +570,49 @@ class MovaiDB:
 
         return True  # need also local
 
-    # ===================  SUBSCRIBERS  ===================================
-    async def subscribe_channel(self, _input: dict, function) -> CallbackSubscription:
-        """Subscribes to a specific channel"""
-        elem = self.dict_to_keys(_input, validate=False)[0]
-        key, _, _ = elem
-        return CallbackSubscription(self.pubsub, key=key + "*", callback=function)
+    # =================== CHECK  SUBSCRIBERS  ===================================
+    def check_registration(self, key: str):
 
-    async def subscribe(self, _input: dict, function) -> None:
+        return SubscribeManager().is_registered(key)
+
+    # ===================  SUBSCRIBERS  ===================================
+    async def subscribe_channel(self, _input: dict, function, port_name: str, node_name: str):
+        """Subscribes to a specific channel"""
+        for elem in self.dict_to_keys(_input, validate=False):
+            key, _, _ = elem
+            self.loop.create_task(self.task_subscriber(key + "*", function, port_name, node_name))
+
+    async def subscribe(self, _input: dict, function):
         """Subscribes to a KeySpace event"""
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=DeprecationWarning)
 
-            elem = self.dict_to_keys(_input, validate=False)[0]
-            key, _, _ = elem
-            sub = CallbackSubscription(self.pubsub, key=f"__keyspace@*__:{key}", callback=function)
-            await sub.subscribe()
+            for elem in self.dict_to_keys(_input, validate=False):
+                key, _, _ = elem
+                self.loop.create_task(
+                    self.task_subscriber("__keyspace@*__:%s" % key, function)
+                )
+
+    async def task_subscriber(self, key: str, callback, port_name: str=None, node_name: str=None  ) -> None:
+        """Calls a callback every time it gets a message."""
+        # Acquires a connection from free pool.
+        # Creates new connection if needed.
+        _conn = await self.pubsub.acquire()
+        # Create Redis interface
+        conn = aioredis.Redis(_conn)
+        # Switch connection to Pub/Sub mode and subscribe to specified patterns
+        channel = await conn.psubscribe(key)
+        if port_name and node_name:
+            SubscribeManager().register_sub(node_name + port_name)
+        # Waits for message to become available in channel
+        while await channel[0].wait_message():
+            msg = await channel[0].get(encoding="utf-8")
+            callback(msg)
+        conn.close()
+        await conn.wait_closed()
+        # Delete from cache the subscribed key 
+        if port_name and node_name:
+            SubscribeManager().unregister_sub(node_name + port_name)
 
     # ===================  List and Hashes  ===============================
     def lpush(self, _input: dict, pickl: bool = True):

--- a/dal/movaidb/database.py
+++ b/dal/movaidb/database.py
@@ -66,6 +66,8 @@ class CallbackSubscription:
         # Inform subscription is ready
         evt.set()
 
+        LOGGER.warning("Waiting")
+
         # Waits for message to become available in channel
         while await self.channel.wait_message():
             msg = await self.channel.get(encoding="utf-8")


### PR DESCRIPTION
By mistake, parts of PR #222 were merged in PR #232. This PR reverts those incorrect merges, while keeping the parts that were correct (the port remapping fix and the Redis mocking tool)

Run the tests on a local sanity robot, the Tugbot worked well.

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~[ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue~


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
