### PR TITLE
Fix syntax error

### DIFF
--- a/dal/plugins/persistence/redis/redis.py
+++ b/dal/plugins/persistence/redis/redis.py
@@ -796,7 +796,7 @@ class RedisPlugin(PersistencePlugin):
         If data is not a dict this will erase all keys defined in schema,
         otherwise it will only delete the passed structure
         """
-        conn = Redis(connection_pool=RedisPlugin._REDIS_MASTER_POOL)
+        conn = Redis(connection_pool=self._REDIS_MASTER_POOL)
 
         if issubclass(type(data), ScopeInstanceVersionNode):
 
@@ -853,7 +853,7 @@ class RedisPlugin(PersistencePlugin):
         force the database layer to rebuild
         all indexes, this is a costly operation
         """
-        conn = Redis(connection_pool=RedisPlugin._REDIS_MASTER_POOL)
+        conn = Redis(connection_pool=self._REDIS_MASTER_POOL)
 
         items = self.list_scopes()
 

--- a/dal/tools/backup.py
+++ b/dal/tools/backup.py
@@ -1147,8 +1147,8 @@ class Exporter(Backup):
 
         try:
             obj = Factory.get_class(scope)(name)
-        except:
-            raise ExportException(f"Can't find {scope}:{name}")
+        except Exception as e:
+            raise ExportException(f"Can't find {scope}:{name} - (Exc: {e})")
 
         json_path = os.path.join(scope, f"{name}.json")
         self.dict2file(obj.get_dict(), json_path)

--- a/dal/tools/backup.py
+++ b/dal/tools/backup.py
@@ -18,6 +18,8 @@ import re
 import sys
 from importlib import import_module
 
+from dal.movaidb import MovaiDB
+
 
 def test_reachable(redis_url):
     """Helper function to test wether a redis_server is reachable or not
@@ -133,6 +135,9 @@ class Backup(object):
         else:
             # prints nothing
             self.log = lambda *args, **kwargs: None
+
+        # Connect to Redis
+        MovaiDB(db="global")
 
     #
     # reads a manifest file and returns


### PR DESCRIPTION
The _REDIS_MASTER_POOL was converted from a class variable to an instance variable, but not all uses in the code where updated. The error in the UI Tests was: `RuntimeError: 500 500: AttributeError: type object 'RedisPlugin' has no attribute '_REDIS_MASTER_POOL'`

Also added explicit connection to Redis on the backup too.


- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~[ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue~


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
