### PR TITLE
BP-1259: Fix bug in GraphicScene API

### DIFF
--- a/dal/data/tree.py
+++ b/dal/data/tree.py
@@ -236,7 +236,7 @@ class ListNode(TreeNode[VT], ChildrenCmpMixin):
         node._parent = None
 
 
-class DictNode(TreeNode[VT], ChildrenCmpMixin, Mapping[str, VT]):
+class DictNode(TreeNode[VT], ChildrenCmpMixin):
     """
     Implements a dict tree node
     """

--- a/dal/data/tree.py
+++ b/dal/data/tree.py
@@ -8,7 +8,7 @@
 """
 from abc import ABC, abstractmethod
 from collections import OrderedDict
-from typing import Dict, Generic, List, Mapping, Optional, Tuple, TypeVar, Union
+from typing import Dict, Generic, List, Optional, Tuple, TypeVar, Union
 from dal.data.mixins import ChildrenCmpMixin, ValueCmpMixin
 
 

--- a/dal/data/tree.py
+++ b/dal/data/tree.py
@@ -143,9 +143,6 @@ class TreeNode(ABC, Generic[VT]):
         number of children
         """
 
-    def __len__(self):
-        return self.count
-
     @property
     @abstractmethod
     def path(self):

--- a/dal/movaidb/database.py
+++ b/dal/movaidb/database.py
@@ -822,9 +822,6 @@ class MovaiDB:
                 keys.append(key_val)
 
     def dict_to_keys(self, _input: dict, validate=None):
-        if validate is not None:
-            LOGGER.warning("Parameter 'validate' of dict_to_keys() is deprecated")
-
         # Keys is a list of tuples with (key, value, source)
         keys: List[Tuple[str, Any, Any]] = list()  # careful with class variables...
         self.validate(_input, self.api_struct, "", keys)


### PR DESCRIPTION
Adding the `__len__` caused Python to change its behavior when the code tests the truthiness of the object (as in, `if obj:`).

Also cleaning up a warning that was way too verbose.

TIcket: [BP-1259](https://movai.atlassian.net/browse/BP-1259)

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository


[BP-1259]: https://movai.atlassian.net/browse/BP-1259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ