### PR TITLE
BP-1250: Bubble up connection errors

### DIFF
--- a/dal/movaidb/database.py
+++ b/dal/movaidb/database.py
@@ -157,6 +157,7 @@ class AioRedisClient(metaclass=Singleton):
 
                         except Exception as e:
                             LOGGER.error(e, exc_info=True)
+                            raise e
                 setattr(self, conn_name, _conn)
 
     @classmethod


### PR DESCRIPTION
When an exception was happening when connecting to Redis, it was logged but never re-raised, so the node got stuck in a bad state. This commit re-raises the exception so it can be handled.

Ticket: [BP-1250](https://movai.atlassian.net/browse/BP-1250)

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
~- [ ] Link to relevant pull requests, esp. upstream and downstream changes~
~- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue~


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository


[BP-1250]: https://movai.atlassian.net/browse/BP-1250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ