### PR TITLE
BP-1263: Fix error when Configuration is not found

### DIFF
--- a/dal/models/configuration.py
+++ b/dal/models/configuration.py
@@ -8,6 +8,7 @@
    - Moawiya Mograni (moawiya@mov.ai) - 2023
 """
 import pickle
+from typing import Any
 import yaml
 from dal.movaidb import MovaiDB
 from .model import Model
@@ -41,33 +42,27 @@ class Configuration(Model):
         # TODO:We can implement a proper caching system later to save this yaml.load operation
         return yaml.load(self.Yaml, Loader=yaml.FullLoader)
 
-    def get_param(self, param: str) -> any:
+    def get_param(self, param: str) -> Any:
         """Returns the configuration value of a key in the format param.subparam.subsubparam"""
 
-        value = None
-
         dict_value = self.get_value()
-
         fields = param.split(".")
 
         try:
             temp_dict = dict_value
 
             for elem in fields:
-                temp_dict = temp_dict[elem] if elem in temp_dict else None
-
+                temp_dict = temp_dict.get(elem)
                 if temp_dict is None:
                     # this means either temp_dict returned None (happens when key: _empty_) or missing key
                     break
 
-            value = temp_dict
+            return temp_dict
 
         except Exception as exc:
             raise Exception(
                 f'"{param}" is not a valid parameter in configuration "{self.path}"'
             ) from exc
-
-        return value
 
 
 # Register class as model of scope Flow

--- a/dal/models/flow.py
+++ b/dal/models/flow.py
@@ -295,7 +295,7 @@ class Flow(Model):
         _context = context or self.ref
 
         # parse the parameter in the context of "_context"
-        output = self.parser.parse(key, param, context=_context)
+        output = self.parser.parse(key, param, "", self, context=_context)
 
         return output
 


### PR DESCRIPTION
When a configuration isn't found, an error is supposed to be logged. There was a bug when the missing configuration was a parameter from the Flow and not a Node.

Ticket: [BP-1263](https://movai.atlassian.net/browse/BP-1263)

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository


[BP-1263]: https://movai.atlassian.net/browse/BP-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ