### PR TITLE
BP-1267: Prevent deleting role with users

### DIFF
--- a/dal/models/baseuser.py
+++ b/dal/models/baseuser.py
@@ -401,7 +401,7 @@ class BaseUser(Model):
         return float(self.LastUpdate)
 
     @classmethod
-    def list_users(cls, domain_name: str) -> list:
+    def list_users(cls, domain_name: str) -> List[str]:
         """lists all the base user fora specified domain
 
         Args:
@@ -418,9 +418,26 @@ class BaseUser(Model):
             if domain_name == user.domain_name:
                 users_names.append(user.account_name)
         cls.log.debug(
-            f"current list of BaseUser records found in the " f"system: {users_names}"
+            f"current list of BaseUser records found in the system: {users_names}"
         )
         return users_names
+
+    @classmethod
+    def has_any_user_with_role(cls, role_name: str) -> bool:
+        """Checks if role is applied to any user
+
+        Args:
+        role_name (str): the name of the role being searched.
+
+        Returns:
+            (bool): whether any user has the role.
+        """
+        for scope in scopes().list_scopes(scope=cls.__name__):
+            principal_name = str(scope["ref"])
+            user = cls.get_user_by_principal_name(principal_name)
+            if role_name in user.roles:
+                return True
+        return False
 
     @classmethod
     def is_exist(cls, domain_name: str, account_name: str):


### PR DESCRIPTION
If a Role has any user assigned to it, an error will be returned when someone tried to delete it.

Tests will be added on the [qa_api_tests](https://github.com/MOV-AI/qa_api_tests/) repository.

Ticket: [BP-1267](https://movai.atlassian.net/browse/BP-1267)

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue (WIP)


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository


[BP-1267]: https://movai.atlassian.net/browse/BP-1267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ