### PR TITLE
BP-1330: Send commands to Robot async

### DIFF
--- a/dal/scopes/fleetrobot.py
+++ b/dal/scopes/fleetrobot.py
@@ -14,7 +14,7 @@ import pickle
 from typing import Dict, Optional
 
 from movai_core_shared.common.utils import is_enterprise
-from movai_core_shared.core.message_client import MessageClient
+from movai_core_shared.core.message_client import MessageClient, AsyncMessageClient
 from movai_core_shared.consts import COMMAND_HANDLER_MSG_TYPE
 from movai_core_shared.envvars import (
     DEVICE_NAME,
@@ -38,6 +38,7 @@ END_TIME_VAR = "endTime"
 class FleetRobot(Scope):
     """Represent the Robot scope in the redis-master."""
     spawner_client: MessageClient
+    async_spawner_client: AsyncMessageClient
     Parameter: Dict
 
     def __init__(self, name: str, version="latest", new=False, db="global"):
@@ -59,6 +60,7 @@ class FleetRobot(Scope):
             server = f"tcp://message-server:{MESSAGE_SERVER_PORT}"
 
         self.__dict__["spawner_client"] = MessageClient(server_addr=server, robot_id=self.RobotName)
+        self.__dict__["async_spawner_client"] = AsyncMessageClient(server_addr=server, robot_id=self.RobotName)
 
     def send_cmd(
         self, command: str, *, flow: str = None, node: str = None, port=None, data=None
@@ -110,6 +112,73 @@ class FleetRobot(Scope):
             ):
                 # success if response is not required or if required, is well formed
                 logger.info("Sent command %s to robot %s", command_data, self.RobotName)
+            else:
+                logger.debug(
+                    "Failed to send command %s %s, response: %s", command_data, self.RobotName, res
+                )
+                send_to_redis = True
+        else:
+            logger.debug("Spawner client not found for %s", self.RobotName)
+            send_to_redis = True
+
+        if send_to_redis:
+            logger.info("Command %s, published in redis for robot %s", command_data, self.RobotName)
+            command_data = pickle.dumps(command_data)
+            self.Actions.append(command_data)
+
+    async def async_send_cmd(
+        self, command: str, *, flow: str = None, node: str = None, port=None, data=None,
+        response_required=False
+    ) -> None:
+        """Send an action command to the Robot.
+
+        See flow-initiator/flow_initiator/spawner/spawner.py for possible commands.
+
+        """
+        dst = {"ip": self.IP, "host": self.RobotName, "id": self.name}
+
+        command_data = {}
+
+        if command:
+            command_data["command"] = command
+
+        if flow:
+            command_data["flow"] = flow
+
+        if node:
+            command_data["node"] = node
+
+        if port:
+            command_data["port"] = port
+
+        if data:
+            command_data["data"] = data
+
+        req_data = {"dst": dst, "command_data": command_data}
+
+        # For retro-compatibility, if the dest robot is a fleet robot
+        # then the response is required since the forward by message-server might fail
+        # in this case, the command will be published to redis
+        send_to_redis = False
+        if self.RobotName != DEVICE_NAME and is_enterprise():
+            logger.debug("%s is a fleet member", self.RobotName)
+            response_required = True
+
+        if hasattr(self, "async_spawner_client") and self.async_spawner_client is not None:
+            res = await self.async_spawner_client.send_request(
+                COMMAND_HANDLER_MSG_TYPE, req_data, response_required=response_required
+            )
+            if not response_required:
+                # success if response is not required or if required, is well formed
+                logger.info("Sent command %s to robot %s", command_data, self.RobotName)
+            elif (
+                res is not None
+                and "response" in res
+                and res["response"] != {}
+            ):
+                # success if response is not required or if required, is well formed
+                logger.info("Sent command %s to robot %s", command_data, self.RobotName)
+                return res["response"]
             else:
                 logger.debug(
                     "Failed to send command %s %s, response: %s", command_data, self.RobotName, res

--- a/dal/scopes/robot.py
+++ b/dal/scopes/robot.py
@@ -9,12 +9,14 @@
 
    Module that implements Robot namespace
 """
+import asyncio
+from typing import Any, Optional
 import uuid
 import pickle
 
-from movai_core_shared.core.message_client import MessageClient
+from movai_core_shared.core.message_client import MessageClient, AsyncMessageClient
 from movai_core_shared.exceptions import DoesNotExist
-from movai_core_shared.consts import COMMAND_HANDLER_MSG_TYPE
+from movai_core_shared.consts import COMMAND_HANDLER_MSG_TYPE, TIMEOUT_SEND_CMD_RESPONSE
 from movai_core_shared.envvars import SPAWNER_BIND_ADDR, DEVICE_NAME
 
 from dal.scopes.scope import Scope
@@ -25,6 +27,8 @@ from .configuration import Configuration
 
 class Robot(Scope):
     """Robot class that deals with robot related stuff"""
+    spawner_client: MessageClient
+    async_spawner_client: AsyncMessageClient
 
     scope = "Robot"
 
@@ -60,6 +64,9 @@ class Robot(Scope):
         # default : ipc:///opt/mov.ai/comm/SpawnerServer-{DEVICE_NAME}-{FLEET_NAME}.sock"
         server = SPAWNER_BIND_ADDR
         self.__dict__["spawner_client"] = MessageClient(server_addr=server, robot_id=self.name)
+        self.__dict__["async_spawner_client"] = AsyncMessageClient(
+            server_addr=server, robot_id=self.name
+        )
 
     def set_ip(self, ip_address: str):
         """Set the IP Adress of the Robot"""
@@ -72,7 +79,9 @@ class Robot(Scope):
         self.fleet.RobotName = name
 
     def send_cmd(self, command, *, flow=None, node=None, port=None, data=None) -> None:
-        """Send an action command to the Robot"""
+        """Send an action command to the Robot
+
+        if wait_for_status is True, we assume the Robot will return a message"""
         command_data = {}
         if command:
             command_data["command"] = command
@@ -97,6 +106,48 @@ class Robot(Scope):
             and self.spawner_client is not None
         ):
             self.spawner_client.send_request(COMMAND_HANDLER_MSG_TYPE, req_data)
+        else:
+            command_data = pickle.dumps(command_data)
+            self.Actions.append(command_data)
+
+    async def async_send_cmd(self, command, *, flow=None, node=None, port=None, data=None, wait_for_status=False) -> Optional[dict]:
+        """Send an action command to the Robot
+        
+        if wait_for_status is True, we assume the Robot will return a message"""
+        command_data = {}
+        if command:
+            command_data["command"] = command
+
+        if flow:
+            command_data["flow"] = flow
+
+        if node:
+            command_data["node"] = node
+
+        if port:
+            command_data["port"] = port
+
+        if data:
+            command_data["data"] = data
+
+        req_data = {"command_data": command_data}
+
+        if (
+            self.RobotName == DEVICE_NAME
+            and hasattr(self, "spawner_client")
+            and self.spawner_client is not None
+        ):
+            try:
+                response = await asyncio.wait_for(
+                    self.async_spawner_client.send_request(
+                        COMMAND_HANDLER_MSG_TYPE, req_data, response_required=wait_for_status
+                    ),
+                    timeout=TIMEOUT_SEND_CMD_RESPONSE,
+                )
+                if wait_for_status:
+                    return {"status": response}
+            except asyncio.TimeoutError:
+                return {"error": "Timeout"}
         else:
             command_data = pickle.dumps(command_data)
             self.Actions.append(command_data)


### PR DESCRIPTION
In order to efficiently wait for a response from the spawner, we can use the Async ZMQ client, which we can await until a response is available

Ticket: [BP-1330](https://movai.atlassian.net/browse/BP-1330)


- [ ] Make sure you are opening from a **topic/feature/bugfix branch**
- [ ] Ensure that the PR title represents the desired changes
- [ ] Ensure that the PR description detail the desired changes
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
