### PR TITLE
BP-1328: Use Redis' TTL support instead

### DIFF
--- a/dal/scopes/structures.py
+++ b/dal/scopes/structures.py
@@ -146,17 +146,6 @@ class Struct:
             return super().__getattribute__(name)
 
         db = MovaiDB(self.db)
-        if name == "Value" and "TTL" in self.attrs:
-            TTL = db.get_value(
-                Helpers.join_first({"TTL": "*"}, self.prev_struct)
-            )
-            if TTL:
-                last_update = db.get_value(
-                    Helpers.join_first({"_timestamp": "*"}, self.prev_struct)
-                )
-                if last_update is not None and last_update + TTL < time.time():
-                    return None
-
         if name in self.attrs:
             return db.get_value(
                 Helpers.join_first({name: "*"}, self.prev_struct)
@@ -223,14 +212,15 @@ class Struct:
         return result
 
     def __setattr__(self, name, value):
-
         if name in self.attrs:
             self.__dict__[name] = value
-            MovaiDB(self.db).set(Helpers.join_first(
-                {name: value}, self.prev_struct))
-            if "TTL" in self.attrs:
-                MovaiDB(self.db).set(Helpers.join_first(
-                    {"_timestamp": time.time()}, self.prev_struct))
+            db = MovaiDB(self.db)
+            TTL = (
+                db.get_value(Helpers.join_first({"TTL": "*"}, self.prev_struct))
+                if name == "Value"
+                else None
+            )
+            db.set(Helpers.join_first({name: value}, self.prev_struct), ex=TTL)
         elif name in self.lists:
             raise AttributeError(f"'{name}' is a list not an attribute")
         elif name in self.hashs:


### PR DESCRIPTION
Improve on #271 by actually deleting the variable after TTL has passed, by reusing Redis' own TTL mechanism. This makes it more robust than only limiting access upon read - in particular, Redis will report the key expiration event.

Ticket: [BP-1328](https://movai.atlassian.net/browse/BP-1328)

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
-  Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
