### PR TITLE
BP-1360: Migrate enterprise model loading to DAL callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
+# vTBD
+- [BP-1360](https://movai.atlassian.net/browse/BP-1360): Metrics no longer available when running cloud function
+
 # v3.0.2
 - [BP-1339](https://movai.atlassian.net/browse/BP-1339): Migrate data-access-layer to py-workflow@v2
+- [BP-1342](https://movai.atlassian.net/browse/BP-1342): Move the middleware and GD_Callback from gd-node (v3.0.2.3)
+- Review Node set_type (v3.0.2.4)
+- [BP-1310](https://movai.atlassian.net/browse/BP-1310): Cache configurations and flow dependencies (v3.0.2.5)
+- [BP-1330](https://movai.atlassian.net/browse/BP-1330): Implement Async Callbacks (v3.0.2.6)
+- [BP-1330](https://movai.atlassian.net/browse/BP-1330): Send commands to Robot async (v3.0.2.7)
+- [BP-1310](https://movai.atlassian.net/browse/BP-1310): Enable fetching yamls directly from db instead of cached (v3.0.2.8)
+- [BP-1328](https://movai.atlassian.net/browse/BP-1328): Add TTL to robot parameters (v3.0.2.9)
 
 # v3.0.1
 - [BP-1322](https://movai.atlassian.net/browse/BP-1322): Move WSRedisSub and Var_Subscriber

--- a/dal/utils/callback.py
+++ b/dal/utils/callback.py
@@ -37,11 +37,22 @@ from dal.scopes.message import Message
 from dal.scopes.robot import Robot
 from dal.scopes.statemachine import StateMachine
 
-if TYPE_CHECKING:
-    try:
-        from movai_core_enterprise.models.graphicscene import GraphicScene
-    except ImportError:
-        pass
+
+try:
+    from movai_core_enterprise.message_client_handlers.alerts import Alerts
+    from movai_core_enterprise.models.annotation import Annotation
+    from movai_core_enterprise.models.graphicasset import GraphicAsset
+    from movai_core_enterprise.models.graphicscene import GraphicScene
+    from movai_core_enterprise.models.layout import Layout
+    from movai_core_enterprise.scopes.task import Task
+    from movai_core_enterprise.models.taskentry import TaskEntry
+    from movai_core_enterprise.models.tasktemplate import TaskTemplate
+    from movai_core_enterprise.message_client_handlers.metrics import Metrics
+
+    enterprise = True
+except ImportError:
+    enterprise = False
+
 
 LOGGER = Log.get_logger("spawner.mov.ai")
 
@@ -347,6 +358,22 @@ class UserFunctions:
                     "Configuration": Configuration,
                 }
             )
+
+            if enterprise:
+                metrics = Metrics()
+                self.globals.update(
+                    {
+                        "Alerts": Alerts,
+                        "Annotation": Annotation,
+                        "GraphicAsset": GraphicAsset,
+                        "GraphicScene": GraphicScene,
+                        "Layout": Layout,
+                        "metrics": metrics,
+                        "Task": Task,
+                        "TaskEntry": TaskEntry,
+                        "TaskTemplate": TaskTemplate,
+                    }
+                )
 
     def load_libraries(self, libraries):
         for lib in libraries:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "data-access-layer"
-version = "3.0.2.9"
+version = "3.0.3.0"
 authors = [
     {name = "Backend team", email = "backend@mov.ai"},
 ]
@@ -59,7 +59,7 @@ dal = [
 line-length = 100
 
 [tool.bumpversion]
-current_version = "3.0.2.9"
+current_version = "3.0.3.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?(\\.(?P<build>\\d+))?"
 serialize = ["{major}.{minor}.{patch}.{build}"]
 


### PR DESCRIPTION
The loading of enterprise models to callbacks was kept in GD-Node, but that's an error because:

1) Backend callbacks require enterprise models like Metrics, so they need to be available outside of GD-Node
2) movai-core-enterprise doesn't depend on gd-node, so there's no issue in loading it in the DAL

Ticket: [BP-1360](https://movai.atlassian.net/browse/BP-1360)

See also https://github.com/MOV-AI/gd-node/pull/127

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository


[BP-1360]: https://movai.atlassian.net/browse/BP-1360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ