### PR TITLE
BP-1365: Fix call to get_param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.2.3
+- [BP-1365](https://movai.atlassian.net/browse/BP-1365): Fix call to get_param
+
 # v3.2.2
 - [BP-1328](https://movai.atlassian.net/browse/BP-1328): Improve TTL on Robot parameters
 

--- a/dal/helpers/parsers.py
+++ b/dal/helpers/parsers.py
@@ -10,12 +10,18 @@
 import ast
 import re
 import os
-from typing import Optional, Protocol
+from typing import TYPE_CHECKING, Any, Optional, Protocol, Union, cast
 
 from movai_core_shared.logger import Log
 from dal.models.scopestree import scopes
 from dal.models.var import Var
 from dal.movaidb import MovaiDB
+
+if TYPE_CHECKING:
+    from dal.models.container import Container
+    from dal.models.flow import Flow
+    from dal.models.nodeinst import NodeInst
+    from dal.models.configuration import Configuration
 
 
 class ObjectWithName(Protocol):
@@ -34,7 +40,7 @@ class ParamParser:
 
     __REGEX__ = r"\$\((param|config|var|flow)[^$)]+\)"
 
-    def __init__(self, flow):
+    def __init__(self, flow: "Flow"):
         self.mapping = {
             "config": self.eval_config,
             "param": self.eval_param,
@@ -54,7 +60,7 @@ class ParamParser:
         node_name: str,
         instance: ObjectWithName,
         context: Optional[str] = None,
-    ) -> any:
+    ) -> Any:
         """
         Returns the parameter value. If the value is a valid expression, it is evaluated.
 
@@ -123,7 +129,7 @@ class ParamParser:
             if result is None:
                 raise ValueError(f"Invalid expression, {expression}")
             # get the function to call from the mapping dict
-            func = self.mapping.get(result.group(1))
+            func = self.mapping[result.group(1)]
 
             # call
             output = func(result.group(2), expression, instance, node_name)
@@ -170,7 +176,7 @@ class ParamParser:
 
         _config_name, _config_param = _config.split(".", 1)
         try:
-            obj = scopes.from_path(_config_name, scope="Configuration")
+            obj = cast("Configuration", scopes.from_path(_config_name, scope="Configuration"))
 
         except KeyError as exc:
             raise ValueError(f"Configuration {_config_name} does not exist") from exc
@@ -179,7 +185,13 @@ class ParamParser:
 
         return output
 
-    def eval_param(self, param_name: str, default: str, instance: any, node_name: str) -> any:
+    def eval_param(
+        self,
+        param_name: str,
+        default: str,
+        instance: Union["Flow", "NodeInst", "Container"],
+        node_name: str,
+    ) -> any:
         """
         Returns the param expression evaluated or default
             ex.: $(param name)
@@ -198,7 +210,7 @@ class ParamParser:
 
         return output
 
-    def eval_var(self, reference: str, *__) -> any:
+    def eval_var(self, reference: str, *__) -> Any:
         """
         Returns the var expression evaluated
             ex.: $(var robot.name)
@@ -223,7 +235,13 @@ class ParamParser:
 
         return output
 
-    def eval_flow(self, param_name, default, instance, node_name) -> any:
+    def eval_flow(
+        self,
+        param_name: str,
+        default: str,
+        instance: Union["NodeInst", "Container"],
+        node_name: str,
+    ) -> any:
         """
         Returns the flow expression evaluated
             ex.: $(flow myvar)
@@ -241,7 +259,7 @@ class ParamParser:
         node_name_arr = node_name.split("__")
         # Check if this is the main flow or a subflow
         is_subflow = len(node_name_arr) > 1
-        value = instance.flow.get_param(param_name, self.context, is_subflow=is_subflow)
+        value = instance.flow.get_param(param_name, context=self.context, is_subflow=is_subflow)
         if value is None:
             value = default
 
@@ -258,6 +276,7 @@ class ParamParser:
 
                     # get the container instance
                     ctr_instance = self.flow.get_container(_name, self.context)
+                    assert ctr_instance is not None, f"Container {_name} not found"
 
                     # get the instance parameter value
                     # if there is no instance param, set to default

--- a/dal/helpers/parsers.py
+++ b/dal/helpers/parsers.py
@@ -206,7 +206,14 @@ class ParamParser:
             output (any): the value of the parameter or the default
         """
 
-        output = instance.get_param(param_name, node_name, self.context) or default
+        cls_name = type(instance).__name__
+        if cls_name == "Flow":  # Flows don't have a node name
+            instance = cast("Flow", instance)
+            output = instance.get_param(param_name, self.context) or default
+        elif cls_name in ["NodeInst", "Container"]:
+            output = instance.get_param(param_name, node_name, self.context) or default
+        else:
+            raise ValueError(f'Instance type "{cls_name}" not supported')
 
         return output
 

--- a/dal/models/container.py
+++ b/dal/models/container.py
@@ -6,7 +6,7 @@
    Developers:
    - Manuel Silva  (manuel.silva@mov.ai) - 2020
 """
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 from .scopestree import ScopeObjectNode, ScopeNode, scopes
 
@@ -23,7 +23,7 @@ class Container(ScopeObjectNode):
     ContainerFlow: str
 
     @property
-    def flow(self):
+    def flow(self) -> "Flow":
         """Returns the parent flow instance (Flow)"""
         return self.parent.parent
 
@@ -56,11 +56,11 @@ class Container(ScopeObjectNode):
     def get_param(
         self,
         key: str,
-        name: str = None,
-        context=None,
-        custom_parser: any = None,
-        default_value: any = None,
-    ) -> any:
+        name: Optional[str] = None,
+        context: Optional[str] = None,
+        custom_parser: Optional[Any] = None,
+        default_value: Optional[Any] = None,
+    ) -> Any:
         """
         Returns a specific parameter of the container after
         parsing it

--- a/dal/models/flow.py
+++ b/dal/models/flow.py
@@ -274,7 +274,6 @@ class Flow(Model):
     def get_param(
         self,
         key: str,
-        node_name: Optional[str] = None,
         context: Optional[str] = None,
         is_subflow: bool = False,
     ) -> Any:

--- a/dal/models/flow.py
+++ b/dal/models/flow.py
@@ -271,7 +271,13 @@ class Flow(Model):
 
         return output
 
-    def get_param(self, key: str, context: str = None, is_subflow: bool = False) -> any:
+    def get_param(
+        self,
+        key: str,
+        node_name: Optional[str] = None,
+        context: Optional[str] = None,
+        is_subflow: bool = False,
+    ) -> Any:
         """
         Returns a parameter of the flow after parsing it
         """

--- a/dal/models/nodeinst.py
+++ b/dal/models/nodeinst.py
@@ -7,13 +7,14 @@
    - Alexandre Pires  (alexandre.pires@mov.ai) - 2020
    - Manuel Sila  (manuel.silva@mov.ai) - 2020
 """
-from typing import Optional, TYPE_CHECKING, cast
+from typing import Optional, TYPE_CHECKING, cast, Any
 
 from .scopestree import ScopeObjectNode, ScopeNode, scopes
 from movai_core_shared.logger import Log
 
 if TYPE_CHECKING:
     from dal.models.node import Node
+    from dal.models.flow import Flow
 
 
 class NodeInst(ScopeObjectNode):
@@ -26,7 +27,7 @@ class NodeInst(ScopeObjectNode):
     logger = Log.get_logger("NodeInst.mov.ai")
 
     @property
-    def flow(self):
+    def flow(self) -> "Flow":
         """Returns the flow (Flow)"""
         return self.parent.parent
 
@@ -151,8 +152,12 @@ class NodeInst(ScopeObjectNode):
         return params
 
     def get_param(
-        self, key: str, name: str = None, context: str = None, custom_parser: any = None
-    ) -> any:
+        self,
+        key: str,
+        name: Optional[str] = None,
+        context: Optional[str] = None,
+        custom_parser: Optional[Any] = None,
+    ) -> Any:
         """
         Returns a specific parameter of the node instance after
         parsing it

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "data-access-layer"
-version = "3.2.2.1"
+version = "3.2.3.0"
 authors = [
     {name = "Backend team", email = "backend@mov.ai"},
 ]
@@ -59,7 +59,7 @@ dal = [
 line-length = 100
 
 [tool.bumpversion]
-current_version = "3.2.2.1"
+current_version = "3.2.3.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?(\\.(?P<build>\\d+))?"
 serialize = ["{major}.{minor}.{patch}.{build}"]
 


### PR DESCRIPTION
When trying to get a parameter from a parent flow, there was a bug that set the incorrect context,
due to an incorrect call to get_param()

Ticket: [BP-1365](https://movai.atlassian.net/browse/BP-1365)

Test PR: https://github.com/MOV-AI/movai_qa_platform_tests/pull/160

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository


[BP-1365]: https://movai.atlassian.net/browse/BP-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ