### PR TITLE
BP-1431: Add tests for node transitions

### DIFF
--- a/dal/models/flowlinks.py
+++ b/dal/models/flowlinks.py
@@ -92,7 +92,7 @@ class FlowLinks(ScopePropertyNode):
             output["Dependency"] = dep_level if (3 >= dep_level >= 0) else 0
 
         except Exception as error:
-            raise ValueError("Invalid link format") from error
+            raise ValueError("Invalid link format: %s" % link[direction]) from error
 
         return output
 
@@ -154,8 +154,8 @@ class FlowLinks(ScopePropertyNode):
         src_separator = "__" if source_type == "MovAI/Flow" else "/"
         trg_separator = "__" if target_type == "MovAI/Flow" else "/"
 
-        source = src_separator.join([source_node, source_port])
-        target = trg_separator.join([target_node, target_port])
+        source = src_separator.join([source_node, source_port, source_type])
+        target = trg_separator.join([target_node, target_port, target_type])
 
         new_link = {"From": source, "To": target}
 

--- a/dal/models/flowlinks.py
+++ b/dal/models/flowlinks.py
@@ -92,7 +92,7 @@ class FlowLinks(ScopePropertyNode):
             output["Dependency"] = dep_level if (3 >= dep_level >= 0) else 0
 
         except Exception as error:
-            raise ValueError("Invalid link format: %s" % link[direction]) from error
+            raise ValueError("Invalid link format: %s" % link) from error
 
         return output
 

--- a/dal/movaidb/database.py
+++ b/dal/movaidb/database.py
@@ -1066,7 +1066,7 @@ class MovaiDB:
             curr = curr.get(key)
             # Check if path exists
         if len(pieces):
-            LOGGER.warning("Couldn't process %s on dict %s", path, base_dict)
+            LOGGER.debug("Couldn't process %s on dict %s", path, base_dict)
             return None
         return curr
 

--- a/tests/unit/test_transitions.py
+++ b/tests/unit/test_transitions.py
@@ -1,0 +1,256 @@
+from functools import partial
+import unittest
+from unittest.mock import MagicMock, patch
+from dal.models.flow import Flow
+from dal.models.flowlinks import FlowLinks
+
+
+class TestFlowGetNodeDependencies(unittest.TestCase):
+    def setUp(self):
+        # We essentially create a mock flow object, with false data,
+        # but the methods are real, so we can test the logic
+        self.flow = MagicMock(name="MockedFlow")
+        self.flow.__START__ = "START/START/START"
+        self.flow.__END__ = "END/END/END"
+        self.flow.workspace = "global"
+        self.flow.Container = {}
+        # The 'partial' means that we are binding the mock flow as the 'self' argument
+        self.flow.get_node_dependencies = partial(Flow.get_node_dependencies, self.flow)
+        self.flow.get_node_transitions = partial(Flow.get_node_transitions, self.flow)
+        self.flow.get_node_inst = partial(Flow.get_node_inst, self.flow)
+        self.flow._with_prefix = partial(Flow._with_prefix, self.flow)
+
+        nodeinst = MagicMock()
+        nodeinst.node_template.get_port.return_value.is_transition.return_value = False
+        nodeinst.is_state = False
+
+        # Mock attributes required for the test
+        self.flow.NodeInst = {
+            "NodeA": nodeinst,
+            "NodeB": nodeinst,
+            "NodeC": nodeinst,
+        }
+        self.flow.Links = FlowLinks("Links", {})
+        self.flow.Links._parent = self.flow
+        self.flow.full = Flow.get_dict(self.flow)
+
+    @patch("dal.models.flow.scopes.from_path")
+    def test_get_node_dependencies_no_dependencies(self, mock_scopes):
+        mock_scopes.return_value = self.flow
+
+        # Test with a node that has no dependencies
+        dependencies = self.flow.get_node_dependencies("NodeA")
+        self.assertEqual(dependencies, [])
+
+    @patch("dal.models.flow.scopes.from_path")
+    def test_get_node_dependencies_with_dependencies(self, mock_scopes):
+        mock_scopes.return_value = self.flow
+
+        # Create links with dependencies
+        self.flow.Links.add(
+            source_node="NodeA",
+            source_port="port1",
+            target_node="NodeB",
+            target_port="port2",
+            source_type="out",
+            target_type="in",
+        )
+        self.flow.Links.add(
+            source_node="NodeC",
+            source_port="port3",
+            target_node="NodeA",
+            target_port="port4",
+            source_type="in",
+            target_type="out",
+        )
+        self.assertEqual(self.flow.Links.count(), 2)
+        self.flow.full = Flow.get_dict(self.flow)
+
+        # Test with a node that has dependencies
+        dependencies = self.flow.get_node_dependencies("NodeA")
+        self.assertEqual(set(dependencies), {"NodeB", "NodeC"})
+
+    @patch("dal.models.flow.scopes.from_path")
+    def test_get_node_dependencies_skip_recursion(self, mock_scopes):
+        mock_scopes.return_value = self.flow
+
+        # Create links with circular dependencies including an extra node
+        self.flow.Links.add(
+            source_node="NodeA",
+            source_port="port1",
+            target_node="NodeB",
+            target_port="port2",
+            source_type="out",
+            target_type="in",
+        )
+        self.flow.Links.add(
+            source_node="NodeB",
+            source_port="port3",
+            target_node="NodeC",
+            target_port="port4",
+            source_type="in",
+            target_type="out",
+        )
+        self.flow.Links.add(
+            source_node="NodeC",
+            source_port="port5",
+            target_node="NodeA",
+            target_port="port6",
+            source_type="out",
+            target_type="in",
+        )
+        self.assertEqual(self.flow.Links.count(), 3)
+        self.flow.full = Flow.get_dict(self.flow)
+
+        dependencies = self.flow.get_node_dependencies("NodeA")
+        self.assertEqual(set(dependencies), {"NodeB", "NodeC"})
+
+    @patch("dal.models.flow.scopes.from_path")
+    def test_get_node_dependencies_first_level_only(self, mock_scopes):
+        mock_scopes.return_value = self.flow
+
+        # Create links with multiple levels of dependencies
+        self.flow.Links.add(
+            source_node="NodeA",
+            source_port="port1",
+            target_node="NodeB",
+            target_port="port2",
+            source_type="out",
+            target_type="in",
+        )
+        self.flow.Links.add(
+            source_node="NodeB",
+            source_port="port3",
+            target_node="NodeC",
+            target_port="port4",
+            source_type="in",
+            target_type="out",
+        )
+        self.assertEqual(self.flow.Links.count(), 2)
+        self.flow.full = Flow.get_dict(self.flow)
+
+        dependencies = self.flow.get_node_dependencies("NodeA", first_level_only=True)
+        self.assertEqual(set(dependencies), {"NodeB"})
+
+
+class TestFlowGetNodeTransitions(unittest.TestCase):
+    def setUp(self):
+        # We essentially create a mock flow object, with false data,
+        # but the methods are real, so we can test the logic
+        self.flow = MagicMock(name="MockedFlow")
+        self.flow.__START__ = "START/START/START"
+        self.flow.__END__ = "END/END/END"
+        self.flow.workspace = "global"
+        self.flow.Container = {}
+        # The 'partial' means that we are binding the mock flow as the 'self' argument
+        self.flow.get_node_dependencies = partial(Flow.get_node_dependencies, self.flow)
+        self.flow.get_node_transitions = partial(Flow.get_node_transitions, self.flow)
+        self.flow.get_node_inst = partial(Flow.get_node_inst, self.flow)
+        self.flow._with_prefix = partial(Flow._with_prefix, self.flow)
+
+        nodeinst = MagicMock()
+        nodeinst.node_template.get_port.return_value.is_transition.return_value = True
+        nodeinst.is_state = False
+
+        # Mock attributes required for the test
+        self.flow.NodeInst = {
+            "NodeA": nodeinst,
+            "NodeB": nodeinst,
+            "NodeC": nodeinst,
+        }
+        self.flow.Links = FlowLinks("Links", {})
+        self.flow.Links._parent = self.flow
+        self.flow.full = Flow.get_dict(self.flow)
+
+    @patch("dal.models.flow.scopes.from_path")
+    def test_get_node_transitions_no_transitions(self, mock_scopes):
+        mock_scopes.return_value = self.flow
+
+        # Test with a node that has no transitions
+        transitions = self.flow.get_node_transitions("NodeA")
+        self.assertEqual(transitions, set())
+
+    @patch("dal.models.flow.scopes.from_path")
+    def test_get_node_transitions_with_transitions(self, mock_scopes):
+        mock_scopes.return_value = self.flow
+
+        # Create links with transitions
+        self.flow.Links.add(
+            source_node="NodeA",
+            source_port="port1",
+            target_node="NodeB",
+            target_port="port2",
+            source_type="out",
+            target_type="in",
+        )
+        self.flow.Links.add(
+            source_node="NodeA",
+            source_port="port3",
+            target_node="NodeC",
+            target_port="port4",
+            source_type="out",
+            target_type="in",
+        )
+        self.assertEqual(self.flow.Links.count(), 2)
+        self.flow.full = Flow.get_dict(self.flow)
+
+        # Test with a node that has transitions
+        transitions = self.flow.get_node_transitions("NodeA")
+        self.assertEqual(transitions, {"NodeB", "NodeC"})
+
+    @patch("dal.models.flow.scopes.from_path")
+    def test_get_node_transitions_filtered_by_port(self, mock_scopes):
+        mock_scopes.return_value = self.flow
+
+        # Create links with transitions
+        self.flow.Links.add(
+            source_node="NodeA",
+            source_port="port1",
+            target_node="NodeB",
+            target_port="port2",
+            source_type="out",
+            target_type="in",
+        )
+        self.flow.Links.add(
+            source_node="NodeA",
+            source_port="port3",
+            target_node="NodeC",
+            target_port="port4",
+            source_type="out",
+            target_type="in",
+        )
+        self.assertEqual(self.flow.Links.count(), 2)
+        self.flow.full = Flow.get_dict(self.flow)
+
+        # Test with a node filtered by port name
+        transitions = self.flow.get_node_transitions("NodeA", port_name="port1")
+        self.assertEqual(transitions, {"NodeB", "NodeC"})
+
+    @patch("dal.models.flow.scopes.from_path")
+    def test_get_node_transitions_no_transition_ports(self, mock_scopes):
+        mock_scopes.return_value = self.flow
+
+        # Mock NodeInst to return False for is_transition
+        self.flow.NodeInst[
+            "NodeA"
+        ].node_template.get_port.return_value.is_transition.return_value = False
+
+        # Create links
+        self.flow.Links.add(
+            source_node="NodeA",
+            source_port="port1",
+            target_node="NodeB",
+            target_port="port2",
+            source_type="out",
+            target_type="in",
+        )
+        self.assertEqual(self.flow.Links.count(), 1)
+        self.flow.full = Flow.get_dict(self.flow)
+
+        # Test with a node that has no transition ports
+        transitions = self.flow.get_node_transitions("NodeA")
+        self.assertEqual(transitions, set())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds unit tests that cover the get_node_dependencies and get_node_transitions methods of the Flow class.

Ticket: [BP-1431](https://movai.atlassian.net/browse/BP-1431)

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository


[BP-1431]: https://movai.atlassian.net/browse/BP-1431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ