### PR TITLE
BP-1412: Cache Redis keys

### DIFF
--- a/dal/movaidb/database.py
+++ b/dal/movaidb/database.py
@@ -9,11 +9,12 @@
    - Moawiya Mograbi (moawiya@mov.ai) - 2022
 """
 
+from collections import defaultdict
 import fnmatch
 import asyncio
 import pickle
 import warnings
-from os import getenv, path
+from os import path
 from re import split
 from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
@@ -22,8 +23,18 @@ import dal
 import redis
 from deepdiff import DeepDiff
 from redis.client import Pipeline
-from redis.connection import Connection
 
+from dal.movaidb.redis_clients import (
+    Redis,
+    AioRedisClient,  # noqa: F401 - for backward compatibility
+    REDIS_MASTER_HOST,
+    REDIS_MASTER_PORT,
+    REDIS_SLAVE_HOST,
+    REDIS_SLAVE_PORT,
+    REDIS_LOCAL_HOST,
+    REDIS_LOCAL_PORT,
+)
+from dal.movaidb.keys_cache import RedisIndexedCache, RedisType
 from dal.classes import Singleton
 from dal.plugins.classes import Resource
 from movai_core_shared.exceptions import InvalidStructure
@@ -71,6 +82,65 @@ def longest_common_prefix(strings: List[str]) -> str:
     return strings[0]
 
 
+def extract_keys(
+    data: Dict[str, Any],
+    schema: Dict[str, Any],
+    path: str = ""
+) -> List[Tuple[str, Any, str]]:
+    """
+    Validates a nested dictionary against a schema and returns a list of (key_path, value, type).
+
+    Args:
+        data: The input dictionary to validate.
+        schema: The schema definition.
+        path: Internal recursive key path (used during traversal).
+
+    Returns:
+        A list of (key_path, value, schema_type) tuples.
+
+    Raises:
+        ValueError: If the input does not match the schema.
+    """
+    results = []
+
+    for key, value in data.items():
+        matched = False
+        next_schema = None
+        key_path = path
+
+        for schema_key, schema_val in schema.items():
+            if schema_key.startswith("$"):
+                # Dynamic key match
+                key_path += f"{key},"
+                next_schema = schema_val
+                matched = True
+                break
+            if schema_key == key:
+                # Static key match
+                key_path += f"{key}:"
+                next_schema = schema_val
+                matched = True
+                break
+
+        if not matched:
+            raise ValueError(f"Unexpected key '{key}' at path '{path}'")
+
+        # If the next schema level is a dict, recurse
+        if isinstance(value, dict) and isinstance(next_schema, dict):
+            results.extend(extract_keys(value, next_schema, key_path))
+        else:
+            schema_type = next_schema
+
+            # Handle &name references (use the value in the key)
+            if isinstance(schema_type, str) and schema_type.startswith("&"):
+                key_path += str(value)
+                value = ""  # Store empty value for reference nodes
+
+            results.append((key_path, value, schema_type))
+
+    return results
+
+
 class SubscribeManager(metaclass=Singleton):
     _key_map = {}
 
@@ -85,171 +155,6 @@ class SubscribeManager(metaclass=Singleton):
     @classmethod
     def is_registered(cls, key):
         return key in cls._key_map
-
-
-class AioRedisClient(metaclass=Singleton):
-    """
-    A Singleton class implementing AioRedis API.
-    """
-
-    _databases = {}
-    loop = asyncio.get_event_loop()
-
-    @classmethod
-    def _register_databases(cls):
-        if not cls._databases:
-            cls._databases = {
-                "db_slave": {
-                    "name": "db_slave",
-                    "host": MovaiDB.REDIS_SLAVE_HOST,
-                    "port": MovaiDB.REDIS_SLAVE_PORT,
-                    "mode": None,
-                    "enabled": True,
-                },
-                "db_local": {
-                    "name": "db_local",
-                    "host": MovaiDB.REDIS_LOCAL_HOST,
-                    "port": MovaiDB.REDIS_LOCAL_PORT,
-                    "mode": None,
-                    "enabled": True,
-                },
-                "slave_pubsub": {
-                    "name": "slave_pubsub",
-                    "host": MovaiDB.REDIS_SLAVE_HOST,
-                    "port": MovaiDB.REDIS_SLAVE_PORT,
-                    "mode": "SUB",
-                    "enabled": True,
-                },
-                "local_pubsub": {
-                    "name": "local_pubsub",
-                    "host": MovaiDB.REDIS_LOCAL_HOST,
-                    "port": MovaiDB.REDIS_LOCAL_PORT,
-                    "mode": "SUB",
-                    "enabled": True,
-                },
-                "db_global": {
-                    "name": "db_global",
-                    "host": MovaiDB.REDIS_MASTER_HOST,
-                    "port": MovaiDB.REDIS_MASTER_PORT,
-                    "mode": None,
-                    "enabled": False,
-                },
-            }
-
-    async def shutdown(self):
-        """shutdown connections"""
-        for conn, _ in type(self)._databases.items():
-            if getattr(self, conn) is not None:
-                getattr(self, conn).close()
-        tasks = [
-            getattr(self, db_name).wait_closed()
-            for db_name in type(self)._databases.keys()
-            if getattr(self, db_name) is not None
-        ]
-        await asyncio.gather(*tasks, return_exceptions=True)
-
-    @classmethod
-    async def get_client(cls):
-        """will return class singleton instance
-
-        Returns:
-            AioRedisClient: object of class AioRedisClient
-        """
-        cls._register_databases()
-        instance = cls()
-        await instance._init_databases()
-        return instance
-
-    async def _init_databases(self):
-        """will initialize connection pools"""
-
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            for conn_name, conn_config in type(self)._databases.items():
-                conn_enabled = conn_config.get("enabled", False)
-                _conn = None
-                if conn_enabled:
-                    _conn = getattr(self, conn_name, None)
-                    if not _conn or _conn.closed:
-                        try:
-                            address = (conn_config["host"], conn_config["port"])
-                            if conn_config.get("mode") == "SUB":
-                                _conn = await aioredis.create_pool(
-                                    address,
-                                    minsize=1,
-                                    maxsize=100,
-                                    pool_cls=aioredis.ConnectionsPool,
-                                )
-                            else:
-                                _conn = await aioredis.create_redis_pool(
-                                    address,
-                                    minsize=2,
-                                    maxsize=100,
-                                    timeout=1,
-                                    pool_cls=aioredis.ConnectionsPool,
-                                )
-
-                        except Exception as e:
-                            LOGGER.error(e, exc_info=True)
-                            raise e
-                setattr(self, conn_name, _conn)
-
-    @classmethod
-    def enable_db(cls, db_name):
-        """will enable the given db name
-
-        Args:
-            db_name (str): database name
-        """
-        cls._register_databases()
-        cls._databases[db_name]["enabled"] = True
-
-
-class Redis(metaclass=Singleton):
-    """
-    A Singleton class implementing Redis API.
-    """
-
-    def __init__(self):
-        self.master_pool = redis.ConnectionPool(
-            connection_class=Connection,
-            host=MovaiDB.REDIS_MASTER_HOST,
-            port=MovaiDB.REDIS_MASTER_PORT,
-            db=0,
-        )
-        self.slave_pool = redis.ConnectionPool(
-            connection_class=Connection,
-            host=MovaiDB.REDIS_SLAVE_HOST,
-            port=MovaiDB.REDIS_SLAVE_PORT,
-            db=0,
-        )
-        self.local_pool = redis.ConnectionPool(
-            connection_class=Connection,
-            host=MovaiDB.REDIS_LOCAL_HOST,
-            port=MovaiDB.REDIS_LOCAL_PORT,
-            db=0,
-        )
-
-        self.thread = None
-
-    @property
-    def db_global(self) -> redis.Redis:
-        return redis.Redis(connection_pool=self.master_pool, decode_responses=False)
-
-    @property
-    def db_slave(self) -> redis.Redis:
-        return redis.Redis(connection_pool=self.slave_pool, decode_responses=False)
-
-    @property
-    def db_local(self) -> redis.Redis:
-        return redis.Redis(connection_pool=self.local_pool, decode_responses=False)
-
-    @property
-    def slave_pubsub(self) -> redis.client.PubSub:
-        return self.db_slave.pubsub()
-
-    def local_pubsub(self) -> redis.client.PubSub:
-        return self.db_local.pubsub()
 
 
 class MovaiDB:
@@ -344,12 +249,13 @@ class MovaiDB:
         },
     }
 
-    REDIS_MASTER_HOST = getenv("REDIS_MASTER_HOST", "redis-master")
-    REDIS_MASTER_PORT = int(getenv("REDIS_MASTER_PORT", 6379))
-    REDIS_SLAVE_PORT = int(getenv("REDIS_SLAVE_PORT", REDIS_MASTER_PORT))
-    REDIS_LOCAL_HOST = getenv("REDIS_LOCAL_HOST", "redis-local")
-    REDIS_LOCAL_PORT = int(getenv("REDIS_LOCAL_PORT", 6379))
-    REDIS_SLAVE_HOST = getenv("REDIS_SLAVE_HOST", REDIS_MASTER_HOST)
+    # for backward compatibility
+    REDIS_MASTER_HOST = REDIS_MASTER_HOST
+    REDIS_MASTER_PORT = REDIS_MASTER_PORT
+    REDIS_SLAVE_PORT = REDIS_SLAVE_PORT
+    REDIS_LOCAL_HOST = REDIS_LOCAL_HOST
+    REDIS_LOCAL_PORT = REDIS_LOCAL_PORT
+    REDIS_SLAVE_HOST = REDIS_SLAVE_HOST
 
     def __init__(
         self,
@@ -367,6 +273,8 @@ class MovaiDB:
         for attribute, val in self.db_dict[db].items():
             setattr(self, attribute, getattr(self.movaidb, val))
 
+        self.indexed_cache = RedisIndexedCache(self.db_read)
+
         if _api_version == "latest":
             self.api_struct = MovaiDB.API(url=__SCHEMAS_URL__).get_api()
         else:
@@ -380,6 +288,9 @@ class MovaiDB:
                 self.loop = asyncio.get_event_loop()
             except Exception:
                 self.loop = asyncio.new_event_loop()
+
+    def initialize(self) -> None:
+        self.indexed_cache.initialize_keys_cache()
 
     def search(self, _input: dict) -> list:
         """
@@ -446,6 +357,26 @@ class MovaiDB:
         keys.sort(key=str.lower)
         return keys
 
+    def get_cached_keys(self, _input: dict) -> Dict[RedisType, List[str]]:
+        """
+        Returns a list of keys from the indexed cache that match the input,
+        grouped by the type of the value.
+        This is used to avoid unnecessary SCANs.
+        """
+        output_keys = defaultdict(list)
+        for key, _, _ in self.dict_to_keys(_input):
+            if key[-1] == "*":
+                for keyinfo in self.indexed_cache.get_keys_by_prefix(key[:-1]):
+                    output_keys[keyinfo.type].append(keyinfo.key)
+            else:
+                rtype = self.db_read.type(key).decode("utf-8")
+                if rtype == 'none':
+                    # Key does not exist, skip it
+                    continue
+                output_keys[RedisType(rtype)].append(key)
+        LOGGER.warning("get_cached_keys called with input: %s, returning keys: %s", _input, output_keys)
+        return output_keys
+
     def get2(self, _input: dict) -> Dict[str, Any]:
         keys = self.search_wild(_input)
         scan_values = [(keys[idx], "") for idx, _ in enumerate(keys)]
@@ -453,7 +384,15 @@ class MovaiDB:
 
     def get_value(self, _input: dict, search=True) -> Any:
         if search:  # value might be on the key so we need a search
-            keys = self.search(_input)
+            # keys = self.search(_input)
+            all_keys = self.get_cached_keys(_input)
+            keys = all_keys.pop(RedisType.string, [])
+            if all_keys:
+                LOGGER.warning(
+                    "get_value called with a dict that has more than one type of value. "
+                    "Returning only the string values."
+                    "%s - %s", all_keys, keys
+                )
         else:
             keys = [self.dict_to_keys(_input)[0][0]]
 
@@ -485,25 +424,38 @@ class MovaiDB:
             dict
         """
         keys: Union[str, List[str]]
-        try:
-            keys = self.search(_input)
-        except:
-            keys = self.search_wild(_input)
+        # try:
+        #     keys = self.search(_input)
+        # except:
+        #     keys = self.search_wild(_input)
 
         kv = list()
-        for idx, value in enumerate(self.db_read.mget(keys)):
-            if value:
-                kv.append((keys[idx], self.decode_value(value)))
-            else:  # no value
-                try:  # Is it a hash?
-                    get_hash = self.db_read.hgetall(keys[idx])
-                    kv.append((keys[idx], self.sort_dict(self.decode_hash(get_hash))))
-                except:
-                    try:  # Is it a list?
-                        get_list = self.db_read.lrange(keys[idx], 0, -1)
-                        kv.append((keys[idx], self.decode_list(get_list)))
-                    except:  # is just a None...
-                        pass
+        for rtype, keys in self.get_cached_keys(_input).items():
+            if rtype == RedisType.string:
+                for key, value in zip(keys, self.db_read.mget(keys)):
+                    if not value:
+                        LOGGER.error(
+                            "Key '%s' not found in Redis. The index cache is out of sync.")
+                        continue
+                    kv.append((key, self.decode_value(value)))
+
+
+            elif rtype == RedisType.hash:
+                for key in keys:
+                    get_hash = self.db_read.hgetall(key)
+                    if not get_hash:
+                        LOGGER.error(
+                            "Key '%s' not found in Redis. The index cache is out of sync.")
+                        continue
+                    kv.append((key, self.sort_dict(self.decode_hash(get_hash))))
+            elif rtype == RedisType.list:
+                for key in keys:
+                    get_list = self.db_read.lrange(key, 0, -1)
+                    if not get_list:
+                        LOGGER.error(
+                            "Key '%s' not found in Redis. The index cache is out of sync.")
+                        continue
+                    kv.append((key, self.decode_list(get_list)))
 
         return self.keys_to_dict(kv)
 
@@ -535,8 +487,11 @@ class MovaiDB:
                     previous_key = self.search(search_dict)
                     if not previous_key:
                         db_set.set(key, value, ex=ex, px=px, nx=nx, xx=xx)
+                        self.indexed_cache.add_to_index(key, RedisType.string)
                     elif len(previous_key) == 1:
                         db_set.rename(previous_key[0], key)
+                        self.indexed_cache.remove_from_index(previous_key[0])
+                        self.indexed_cache.add_to_index(key, RedisType.string)
                     else:
                         print("More that 1 key in Redis for the same structure value")
                 else:
@@ -546,14 +501,18 @@ class MovaiDB:
                         if value:
                             db_set.delete(key)
                             db_set.hmset(key, value)
+                            self.indexed_cache.remove_from_index(key)
+                            self.indexed_cache.add_to_index(key, RedisType.hash)
                     elif source == "list":
                         assert isinstance(value, list)
                         for lval in value:
                             if pickl:
                                 lval = pickle.dumps(lval)
                             db_set.rpush(key, lval)
+                        self.indexed_cache.add_to_index(key, RedisType.list)
                     else:
                         db_set.set(key, value, ex=ex, px=px, nx=nx, xx=xx)
+                        self.indexed_cache.add_to_index(key, RedisType.string)
             except Exception as e:
                 LOGGER.error("Something went wrong while saving this in Redis: %s", e)
 
@@ -573,6 +532,8 @@ class MovaiDB:
             return 0
 
         res = db_del.delete(*keys)
+        for key in keys:
+            self.indexed_cache.remove_from_index(key)
         # if we're using a Redis pipeline, we won't get
         # the result until it is executed
         return res if isinstance(res, int) else None
@@ -595,6 +556,8 @@ class MovaiDB:
             return 0
 
         res = db_del.delete(*keys)
+        for key in keys:
+            self.indexed_cache.remove_from_index(key)
         # if we're using a Redis pipeline, we won't get
         # the result until it is executed
         return res if isinstance(res, int) else None
@@ -629,6 +592,8 @@ class MovaiDB:
 
         for old, new in keys:
             self.db_write.rename(old, new)
+            self.indexed_cache.remove_from_index(old)
+            self.indexed_cache.add_to_index(new)
 
         return True  # need also local
 
@@ -764,7 +729,13 @@ class MovaiDB:
     def get_list(self, _input: dict, search=True) -> Any:
         """Gets a full list from Redis"""
         if search:
-            keys = self.search(_input)
+            all_keys = self.get_cached_keys(_input)
+            keys = all_keys.pop(RedisType.list, [])
+            if all_keys:
+                LOGGER.warning(
+                    "get_value called with a dict that has more than one type of value. "
+                    "Returning only the list values."
+                )
         else:
             # just convert the dict to a key
             keys = [self.dict_to_keys(_input)[0][0]]
@@ -775,7 +746,13 @@ class MovaiDB:
     def get_hash(self, _input: dict, search=True) -> Any:
         """Gets a full hash from Redis"""
         if search:
-            keys = self.search(_input)
+            all_keys = self.get_cached_keys(_input)
+            keys = all_keys.pop(RedisType.hash, [])
+            if all_keys:
+                LOGGER.warning(
+                    "get_value called with a dict that has more than one type of value. "
+                    "Returning only the hash values."
+                )
         else:
             # just convert the dict to a key
             keys = [self.dict_to_keys(_input)[0][0]]
@@ -827,45 +804,9 @@ class MovaiDB:
         return pipe.execute()
 
     # ===================  Convert and Validate  ==========================
-    @classmethod
-    def validate(
-        cls, d: Dict[str, Any], api: Dict[str, Any], base_key: str, keys: List[Tuple[str, Any, Any]]
-    ):
-        """Validation before safe in database"""
-        for k, v in d.items():
-            key = base_key
-            is_ok = False
-            for k_api, _ in api.items():
-                if k_api[0] == "$":
-                    key += k + ","
-                    temp_api = api[k_api]
-                    is_ok = True
-                    break
-                elif k == k_api:
-                    key += k + ":"
-                    temp_api = api[k]
-                    is_ok = True
-                    break
-
-            if not is_ok:
-                error_msg = f"Structure provided does not exist: {d}"
-                LOGGER.error(error_msg)
-                raise Exception(error_msg)
-            if isinstance(v, dict) and isinstance(temp_api, dict):
-                cls.validate(v, temp_api, key, keys)
-            else:
-                value = v
-                if temp_api[0] == "&" and v is not None:
-                    key += v
-                    value = ""
-                key_val = (key, value, temp_api)
-                keys.append(key_val)
-
-    def dict_to_keys(self, _input: dict, validate=None):
+    def dict_to_keys(self, _input: dict, validate=None) -> List[Tuple[str, Any, str]]:
         # Keys is a list of tuples with (key, value, source)
-        keys: List[Tuple[str, Any, Any]] = list()  # careful with class variables...
-        self.validate(_input, self.api_struct, "", keys)
-        return keys
+        return extract_keys(_input, self.api_struct)
 
     @staticmethod
     def keys_to_dict(kv: List[Tuple[str, Any]]):

--- a/dal/movaidb/keys_cache.py
+++ b/dal/movaidb/keys_cache.py
@@ -1,0 +1,114 @@
+from enum import Enum
+"""
+Module: keys_cache
+
+This module provides functionality for managing a Redis-based indexed cache. It includes utilities for indexing Redis keys
+based on their prefixes and types, as well as retrieving and managing these keys efficiently.
+
+Classes:
+---------
+1. RedisType(Enum):
+    - Enum representing the different Redis data types (STRING, HASH, LIST, SET, ZSET).
+
+2. RedisIndexedCache:
+    - A class for managing an indexed cache in Redis. It provides methods for adding, removing, and retrieving keys
+      based on their prefixes and types.
+"""
+from typing import Iterable, NamedTuple, Optional, Union
+
+from movai_core_shared import Log
+import redis
+
+LOGGER = Log.get_logger("dal.mov.ai")
+
+
+class RedisType(Enum):
+    STRING = 'string'
+    HASH = 'hash'
+    LIST = 'list'
+    SET = 'set'
+    ZSET = 'zset'
+
+
+KeyInfo = NamedTuple('KeyInfo', [
+    ('key', str),
+    ('type', RedisType),
+])
+
+
+class RedisIndexedCache:
+    def __init__(self, redis_client: redis.Redis, index_prefix: str = "__index__"):
+        self._redis: redis.Redis = redis_client
+        self.index_prefix = index_prefix
+
+    def _get_index_key(self, prefix: str) -> str:
+        return f"{self.index_prefix}:{prefix}"
+
+    def _get_prefix(self, key: str) -> str:
+        parts = key.split(',')
+        for part in parts:
+            if ':' in part:
+                return part  # e.g., Flow:abc
+        return 'misc'
+
+    def add_to_index(self, key: str, redis_type: Optional[RedisType] = None):
+        if redis_type is None:
+            redis_type = RedisType(self._redis.type(key))
+        prefix = self._get_prefix(key)
+        index_key = self._get_index_key(prefix)
+        entry = f"{key}|{redis_type.value}"
+        self._redis.sadd(index_key, entry)
+
+    def remove_from_index(self, key: str):
+        prefix = self._get_prefix(key)
+        index_key = self._get_index_key(prefix)
+        entries = self._redis.smembers(index_key)
+        for entry in entries:
+            entry_str = entry.decode() if isinstance(entry, bytes) else entry
+            if entry_str.startswith(f"{key}|"):
+                self._redis.srem(index_key, entry)
+                break
+
+    def _fetch_by_type(self, key: str, key_type: str) -> Optional[Union[str, dict, list, set]]:
+        if key_type == "string":
+            return self._redis.get(key)
+        if key_type == "hash":
+            return self._redis.hgetall(key)
+        if key_type == "list":
+            return self._redis.lrange(key, 0, -1)
+        if key_type == "set":
+            return self._redis.smembers(key)
+        if key_type == "zset":
+            return self._redis.zrange(key, 0, -1, withscores=True)
+        return None
+
+    def get_keys_by_prefix(self, prefix: str) -> Iterable[KeyInfo]:
+        index_key = self._get_index_key(prefix)
+        entries = self._redis.smembers(index_key)
+        results = set()
+        for entry in entries:
+            entry = entry.decode() if isinstance(entry, bytes) else entry
+            try:
+                key, key_type = entry.rsplit('|', 1)
+                results.add(KeyInfo(key=key, type=RedisType(key_type)))
+            except ValueError:
+                LOGGER.warning(f"Invalid entry format in index: {entry}")
+        return results
+
+    def initialize_keys_cache(self):
+        """Initialize the keys cache by scanning all keys in Redis and adding them to the index."""
+        cursor = 0
+        added_keys = 0
+        while True:
+            cursor, keys = self._redis.scan(cursor=cursor, match='*', count=1000)
+            for key in keys:
+                key = key.decode() if isinstance(key, bytes) else key
+                try:
+                    key_type = RedisType(self._redis.type(key).decode())
+                    self.add_to_index(key, key_type)
+                except redis.RedisError as error:
+                    LOGGER.error(f"Error adding key {key} to index: {error}")
+            added_keys += len(keys)
+            if cursor == 0:
+                break
+        LOGGER.info("Keys cache initialized successfully. %s keys indexed.", added_keys)

--- a/dal/movaidb/redis_clients.py
+++ b/dal/movaidb/redis_clients.py
@@ -1,0 +1,187 @@
+
+import asyncio
+from os import getenv
+import warnings
+
+import aioredis
+import redis
+from redis import Connection
+from movai_core_shared import Log
+
+from dal.classes.common.singleton import Singleton
+
+
+REDIS_MASTER_HOST = getenv("REDIS_MASTER_HOST", "redis-master")
+REDIS_MASTER_PORT = int(getenv("REDIS_MASTER_PORT", 6379))
+REDIS_SLAVE_HOST = getenv("REDIS_SLAVE_HOST", REDIS_MASTER_HOST)
+REDIS_SLAVE_PORT = int(getenv("REDIS_SLAVE_PORT", REDIS_MASTER_PORT))
+REDIS_LOCAL_HOST = getenv("REDIS_LOCAL_HOST", "redis-local")
+REDIS_LOCAL_PORT = int(getenv("REDIS_LOCAL_PORT", 6379))
+
+LOGGER = Log.get_logger("dal.mov.ai")
+
+
+class AioRedisClient(metaclass=Singleton):
+    """
+    A Singleton class implementing AioRedis API.
+    """
+
+    _databases = {}
+    loop = asyncio.get_event_loop()
+
+    @classmethod
+    def _register_databases(cls):
+        if not cls._databases:
+            cls._databases = {
+                "db_slave": {
+                    "name": "db_slave",
+                    "host": REDIS_SLAVE_HOST,
+                    "port": REDIS_SLAVE_PORT,
+                    "mode": None,
+                    "enabled": True,
+                },
+                "db_local": {
+                    "name": "db_local",
+                    "host": REDIS_LOCAL_HOST,
+                    "port": REDIS_LOCAL_PORT,
+                    "mode": None,
+                    "enabled": True,
+                },
+                "slave_pubsub": {
+                    "name": "slave_pubsub",
+                    "host": REDIS_SLAVE_HOST,
+                    "port": REDIS_SLAVE_PORT,
+                    "mode": "SUB",
+                    "enabled": True,
+                },
+                "local_pubsub": {
+                    "name": "local_pubsub",
+                    "host": REDIS_LOCAL_HOST,
+                    "port": REDIS_LOCAL_PORT,
+                    "mode": "SUB",
+                    "enabled": True,
+                },
+                "db_global": {
+                    "name": "db_global",
+                    "host": REDIS_MASTER_HOST,
+                    "port": REDIS_MASTER_PORT,
+                    "mode": None,
+                    "enabled": False,
+                },
+            }
+
+    async def shutdown(self):
+        """shutdown connections"""
+        for conn, _ in type(self)._databases.items():
+            if getattr(self, conn) is not None:
+                getattr(self, conn).close()
+        tasks = [
+            getattr(self, db_name).wait_closed()
+            for db_name in type(self)._databases.keys()
+            if getattr(self, db_name) is not None
+        ]
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    @classmethod
+    async def get_client(cls):
+        """will return class singleton instance
+
+        Returns:
+            AioRedisClient: object of class AioRedisClient
+        """
+        cls._register_databases()
+        instance = cls()
+        await instance._init_databases()
+        return instance
+
+    async def _init_databases(self):
+        """will initialize connection pools"""
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            for conn_name, conn_config in type(self)._databases.items():
+                conn_enabled = conn_config.get("enabled", False)
+                _conn = None
+                if conn_enabled:
+                    _conn = getattr(self, conn_name, None)
+                    if not _conn or _conn.closed:
+                        try:
+                            address = (conn_config["host"], conn_config["port"])
+                            if conn_config.get("mode") == "SUB":
+                                _conn = await aioredis.create_pool(
+                                    address,
+                                    minsize=1,
+                                    maxsize=100,
+                                    pool_cls=aioredis.ConnectionsPool,
+                                )
+                            else:
+                                _conn = await aioredis.create_redis_pool(
+                                    address,
+                                    minsize=2,
+                                    maxsize=100,
+                                    timeout=1,
+                                    pool_cls=aioredis.ConnectionsPool,
+                                )
+
+                        except Exception as e:
+                            LOGGER.error(e, exc_info=True)
+                            raise e
+                setattr(self, conn_name, _conn)
+
+    @classmethod
+    def enable_db(cls, db_name):
+        """will enable the given db name
+
+        Args:
+            db_name (str): database name
+        """
+        cls._register_databases()
+        cls._databases[db_name]["enabled"] = True
+
+
+class Redis(metaclass=Singleton):
+    """
+    A Singleton class implementing Redis API.
+    """
+
+    def __init__(self):
+        self.master_pool = redis.ConnectionPool(
+            connection_class=Connection,
+            host=REDIS_MASTER_HOST,
+            port=REDIS_MASTER_PORT,
+            db=0,
+        )
+        self.slave_pool = redis.ConnectionPool(
+            connection_class=Connection,
+            host=REDIS_SLAVE_HOST,
+            port=REDIS_SLAVE_PORT,
+            db=0,
+        )
+        self.local_pool = redis.ConnectionPool(
+            connection_class=Connection,
+            host=REDIS_LOCAL_HOST,
+            port=REDIS_LOCAL_PORT,
+            db=0,
+        )
+
+        self.thread = None
+
+    @property
+    def db_global(self) -> redis.Redis:
+        return redis.Redis(connection_pool=self.master_pool, decode_responses=False)
+
+    @property
+    def db_slave(self) -> redis.Redis:
+        return redis.Redis(connection_pool=self.slave_pool, decode_responses=False)
+
+    @property
+    def db_local(self) -> redis.Redis:
+        return redis.Redis(connection_pool=self.local_pool, decode_responses=False)
+
+    @property
+    def slave_pubsub(self) -> redis.client.PubSub:
+        return self.db_slave.pubsub()
+
+    def local_pubsub(self) -> redis.client.PubSub:
+        return self.db_local.pubsub()
+

--- a/tests/unit/test_movaidb.py
+++ b/tests/unit/test_movaidb.py
@@ -1,7 +1,70 @@
 import unittest
 import unittest.mock
 
-from dal.movaidb.database import MovaiDB
+from dal.movaidb.database import MovaiDB, extract_keys
+
+import unittest
+from typing import List, Tuple, Any
+
+
+DATA_VALID = {
+    'Robot': {
+        '2dd2cac0bb7b439f8cc923852a19a290': {
+            'Status': {
+                'active_flow': '',
+                'nodes_lchd': [],
+                'persistent_nodes_lchd': [],
+                'active_states': [],
+                'core_lchd': [],
+                'locks': [],
+                'timestamp': 1750946517.3606594,
+                'active_scene': ''
+            }
+        }
+    }
+}
+
+SCHEMA = {
+    "Robot": {
+        "$name": {
+            "Label": "str",
+            "RobotName": "&name",
+            "IP": "ip_add",
+            "RobotType": "str",
+            "RobotModel": "str",
+            "Info": "str",
+            "Actions": "list",
+            "Notifications": "list",
+            "Alerts": "hash",
+            "Status": "hash",
+            "Parameter": {
+                "$name": {
+                    "Value": "any",
+                    "TTL": "int",
+                    "_timestamp": "float"
+                }
+            }
+        }
+    }
+}
+
+EXPECTED_KEYS: List[Tuple[str, Any, str]] = [
+    (
+        'Robot:2dd2cac0bb7b439f8cc923852a19a290,Status:',
+        {
+            'active_flow': '',
+            'nodes_lchd': [],
+            'persistent_nodes_lchd': [],
+            'active_states': [],
+            'core_lchd': [],
+            'locks': [],
+            'timestamp': 1750946517.3606594,
+            'active_scene': ''
+        },
+        'hash'
+    )
+]
+
 
 
 class TestMovaiDB(unittest.TestCase):
@@ -45,23 +108,6 @@ class TestMovaiDB(unittest.TestCase):
         source_dict = {}
         expected_output = {}
         self.assertEqual(MovaiDB.args_to_dict(source_dict, repl), expected_output)
-
-    def test_validate(self):
-        data = {"Value": ["ps_vis_area"]}
-        api = {"Value": "any"}
-        base_key = "SharedDataEntry:ps_group_1,Field:vis_areas,"
-        keys = [
-            ("SharedDataEntry:ps_group_1,Field:scan_areas,Value:", ["ps_1"], "any"),
-            ("SharedDataEntry:ps_group_1,Field:scan_point,Value:", "ps_scan_point", "any"),
-        ]
-
-        expected_result = [
-            ("SharedDataEntry:ps_group_1,Field:scan_areas,Value:", ["ps_1"], "any"),
-            ("SharedDataEntry:ps_group_1,Field:scan_point,Value:", "ps_scan_point", "any"),
-            ("SharedDataEntry:ps_group_1,Field:vis_areas,Value:", ["ps_vis_area"], "any"),
-        ]
-        MovaiDB.validate(data, api, base_key, keys)
-        self.assertEqual(keys, expected_result)
 
     def test_keys_to_dict(self):
         kv = [("Robot:f488dd196a8c441c97a227a315048fc7,RobotName:241_107", "")]
@@ -133,3 +179,33 @@ class TestMovaiDB(unittest.TestCase):
         with unittest.mock.patch.object(movaidb.db_read, "scan_iter", new=mock_scan_iter):
             # Call the search method
             self.assertTrue(movaidb.exists_by_args("SharedDataEntry", Name="ps_group_1"))
+
+
+class TestExtractKeys(unittest.TestCase):
+    def test_valid_structure(self):
+        result = extract_keys(DATA_VALID, SCHEMA)
+        self.assertEqual(result, EXPECTED_KEYS)
+
+    def test_missing_key_raises(self):
+        bad_data = {
+            'Robot': {
+                'some_id': {
+                    'MissingStatus': {}
+                }
+            }
+        }
+        with self.assertRaises(ValueError) as context:
+            extract_keys(bad_data, SCHEMA)
+        self.assertIn("Unexpected key", str(context.exception))
+
+    def test_reference_key(self):
+        data = {
+            'Robot': {
+                'robot42': {
+                    'RobotName': 'robot42'
+                }
+            }
+        }
+        expected = [('Robot:robot42,RobotName:robot42', '', '&name')]
+        result = extract_keys(data, SCHEMA)
+        self.assertEqual(result, expected)


### PR DESCRIPTION
Add a caching mechanism to avoid regular SCANs in the Redis database. Key sections are stored using Redis Sets, so a key like `Robot:ABCD,RobotName:` will have a set named `Robot:ABCD` with `RobotName:` as one of its values. This way, listing all the keys under `Robot:ABCD` becomes a quick set read instead of an expensive full-database SCAN.

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
