### PR TITLE
BP-1470: Move DEFAULT_LANGUAGE to a central location, for reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.7.1
+- [BP-1470](https://movai.atlassian.net/browse/BP-1470): Move DEFAULT_LANGUAGE to central location
+
 # v3.7.0
 - [BP-1456](https://movai.atlassian.net/browse/BP-1456): Add support for user language configuration
   - Introduced `language` attribute for `BaseUser` and `InternalUser` models.

--- a/dal/models/baseuser.py
+++ b/dal/models/baseuser.py
@@ -25,11 +25,9 @@ from movai_core_shared.consts import (
 from dal.models.scopestree import ScopesTree, scopes
 from dal.models.model import Model
 from dal.models.acl import NewACLManager
-from dal.scopes.application import Application
 from dal.models.acl import ResourceType, ApplicationsType
-
-
-DEFAULT_LANGUAGE = "en"
+from dal.scopes.application import Application
+from dal.scopes.translation import DEFAULT_LANGUAGE
 
 
 class BaseUser(Model):

--- a/dal/models/internaluser.py
+++ b/dal/models/internaluser.py
@@ -12,8 +12,9 @@ from movai_core_shared.consts import INTERNAL_DOMAIN
 from movai_core_shared.exceptions import PasswordError, PasswordComplexityError
 
 from dal.models.model import Model
-from dal.models.baseuser import DEFAULT_LANGUAGE, BaseUser
+from dal.models.baseuser import BaseUser
 from dal.models.user import User
+from dal.scopes.translation import DEFAULT_LANGUAGE
 
 
 class InternalUser(BaseUser):

--- a/dal/scopes/translation.py
+++ b/dal/scopes/translation.py
@@ -1,5 +1,7 @@
-"""Translation scope."""
 from .scope import Scope
+
+
+DEFAULT_LANGUAGE = "en"
 
 
 class Translation(Scope):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "data-access-layer"
-version = "3.7.0.1"
+version = "3.7.1.0"
 authors = [
     {name = "Backend team", email = "backend@mov.ai"},
 ]
@@ -60,7 +60,7 @@ dal = [
 line-length = 100
 
 [tool.bumpversion]
-current_version = "3.7.0.1"
+current_version = "3.7.1.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?(\\.(?P<build>\\d+))?"
 serialize = ["{major}.{minor}.{patch}.{build}"]
 


### PR DESCRIPTION
Changes for https://github.com/MOV-AI/backend/pull/310

Ticket: [BP-1470](https://movai.atlassian.net/browse/BP-1470)

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes



[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
