### PR TITLE
Leave type validation to _validate_content

### DIFF
--- a/dal/validation/json_schema/2.4/Node.schema.json
+++ b/dal/validation/json_schema/2.4/Node.schema.json
@@ -169,8 +169,7 @@
             "type": ["boolean", "string"]
         },
         "Type": {
-            "type": "string",
-            "enum": ["ROS1/Node","ROS1/Plugin", "MovAI/Node", "MovAI/State", "MovAI/Server", "ROS2/Node", "ROS2/Launch"]
+            "type": "string"
         },
         "ContainerConf": {
             "type": "object"

--- a/tests/unit/data/invalid/metadata/Node/delete_me.json
+++ b/tests/unit/data/invalid/metadata/Node/delete_me.json
@@ -25,7 +25,7 @@
                 }
             },
             "Remappable": true,
-            "Type": "invalid_data",
+            "invalid_data": "invalid_data",
             "User": "",
             "Version": "",
             "VersionDelta": {}


### PR DESCRIPTION
- [BP-1651](https://movai.atlassian.net/browse/BP-1651): ROS2 - Enable ROS2 Node and Launch template creation
  - Type options were validated both in the json schema and in _validate_content, unnecessary duplication

[BP-1651]: https://movai.atlassian.net/browse/BP-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ