### PR TITLE
BP-1683: We should not be able to create a State Node with only MovAI/Init and MovAI/Exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## vTBD
+- [BP-1683](https://movai.atlassian.net/browse/BP-1683): We should not be able to create a State Node with only MovAI/Init and MovAI/Exit
+
 ## v3.24.0
 - [BP-1651](https://movai.atlassian.net/browse/BP-1651): ROS2 - Enable ROS2 Node and Launch template creation
 

--- a/dal/scopes/node.py
+++ b/dal/scopes/node.py
@@ -548,7 +548,14 @@ class Node(Scope):
         - Type must be one of the defined NODE_TYPES
         - If Type is ROS1, PortsInst cannot have ROS2 templates
         - If Type is ROS2, PortsInst cannot have ROS1 templates
+        - If Type is MovAI/State, PortsInst must have at least one transition template
         - If Type is not MovAI/State, PortsInst cannot have transition templates
+        - If Type is ROS1/Plugin, PortsInst must have at least one ROS1/PluginClient template
+        - If Type is not ROS1/Plugin, PortsInst cannot have ROS1/PluginClient templates
+        - If Type is ROS1/Nodelet, PortsInst must have at least one ROS1/NodeletClient or ROS1/NodeletServer template
+        - If Type is not ROS1/Nodelet, PortsInst cannot have ROS1/NodeletClient or ROS1/NodeletServer templates
+        - If Type is MOVAI/Server, PortsInst must have at least one MOVAI http template
+        - If Type is not MOVAI/Server, PortsInst cannot have MOVAI http templates
 
         Raises:
             ValueError: If any of the validations fail.
@@ -574,30 +581,50 @@ class Node(Scope):
             if ROS1_PORT_TEMPLATES & port_templates:
                 raise ValueError(f"{node_type} nodes cannot have ROS1 ports")
 
-        if node_type != MOVAI_STATE:
+        if node_type == MOVAI_STATE:
+            # must have at least one transition port
+            if not {MOVAI_TRANSITION, MOVAI_TRANSITIONFOR, MOVAI_TRANSITIONTO} & port_templates:
+                raise ValueError(f"{node_type} nodes must have at least one transition port")
+        else:
             # no transition ports allowed
-            if port_templates & {
+            if {
                 MOVAI_TRANSITION,
                 MOVAI_TRANSITIONFOR,
                 MOVAI_TRANSITIONTO,
-            }:
+            } & port_templates:
                 raise ValueError(f"{node_type} nodes cannot have transition ports")
 
-        if node_type != ROS1_PLUGIN:
+        if node_type == ROS1_PLUGIN:
+            # must have at least one plugin client port
+            if ROS1_PLUGINCLIENT not in port_templates:
+                raise ValueError(
+                    f"{node_type} nodes must have at least one {ROS1_PLUGINCLIENT} port"
+                )
+        else:
             # no ROS1 plugin client ports allowed
             if {
                 ROS1_PLUGINCLIENT,
             } & port_templates:
                 raise ValueError(f"{node_type} nodes cannot have {ROS1_PLUGINCLIENT} ports")
 
-        if node_type != ROS1_NODELET:
+        if node_type == ROS1_NODELET:
+            # must have at least one nodelet client or server port
+            if not {ROS1_NODELETCLIENT, ROS1_NODELETSERVER} & port_templates:
+                raise ValueError(
+                    f"{node_type} nodes must have at least one {ROS1_NODELETCLIENT} or {ROS1_NODELETSERVER} port"
+                )
+        else:
             # no ROS1 nodelet client ports allowed
-            if port_templates & {ROS1_NODELETCLIENT, ROS1_NODELETSERVER}:
+            if {ROS1_NODELETCLIENT, ROS1_NODELETSERVER} & port_templates:
                 raise ValueError(
                     f"{node_type} nodes cannot have {ROS1_NODELETCLIENT} or {ROS1_NODELETSERVER} ports"
                 )
 
-        if node_type != MOVAI_SERVER:
+        if node_type == MOVAI_SERVER:
+            # must have at least one MOV.AI http port
+            if not AIOHTTP_PORT_TEMPLATES & port_templates:
+                raise ValueError(f"{node_type} nodes must have at least one http port")
+        else:
             # no MOV.AI http ports allowed
-            if port_templates & AIOHTTP_PORT_TEMPLATES:
+            if AIOHTTP_PORT_TEMPLATES & port_templates:
                 raise ValueError(f"{node_type} nodes cannot have http ports")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dal = [
 line-length = 100
 
 [tool.bumpversion]
-current_version = "3.24.0.3"
+current_version = "3.24.1.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?(\\.(?P<build>\\d+))?"
 serialize = ["{major}.{minor}.{patch}.{build}"]
 

--- a/tests/unit/validation/test_schema.py
+++ b/tests/unit/validation/test_schema.py
@@ -141,6 +141,25 @@ class TestNodeSchema:
         with pytest.raises(ValueError, match="ROS2/Node nodes cannot have"):
             Node.validate_format("Node", data)
 
+    def test_validate_state_no_transition_port(self):
+        """Test that a MovAI/State node without a transition port fails validation."""
+        from dal.scopes.node import Node
+
+        data = {
+            "Type": "MovAI/State",
+            "PortsInst": {
+                "pubport": {
+                    "Message": "Float32",
+                    "Out": {"out": {"Message": "std_msgs/Float32"}},
+                    "Package": "std_msgs",
+                    "Template": "ROS1/Publisher",
+                }
+            },
+        }
+
+        with pytest.raises(ValueError, match="MovAI/State nodes must have"):
+            Node.validate_format("Node", data)
+
     def test_validate_ros1_node_transition_port(self):
         """Test that a ROS1 node with a transition port fails validation."""
         from dal.scopes.node import Node
@@ -160,6 +179,25 @@ class TestNodeSchema:
         }
 
         with pytest.raises(ValueError, match="ROS1/Node nodes cannot have"):
+            Node.validate_format("Node", data)
+
+    def test_validate_ros1_plugin_no_plugin_port(self):
+        """Test that a ROS1/Plugin node without a plugin client port fails validation."""
+        from dal.scopes.node import Node
+
+        data = {
+            "Type": "ROS1/Plugin",
+            "PortsInst": {
+                "pubport": {
+                    "Message": "Float32",
+                    "Out": {"out": {"Message": "std_msgs/Float32"}},
+                    "Package": "std_msgs",
+                    "Template": "ROS1/Publisher",
+                }
+            },
+        }
+
+        with pytest.raises(ValueError, match="ROS1/Plugin nodes must have"):
             Node.validate_format("Node", data)
 
     def test_validate_ros1_node_plugin_client_port(self):
@@ -182,6 +220,25 @@ class TestNodeSchema:
         with pytest.raises(ValueError, match="ROS1/Node nodes cannot have"):
             Node.validate_format("Node", data)
 
+    def test_validate_ros1_nodelet_no_nodelet_port(self):
+        """Test that a ROS1/Nodelet node without a nodelet client or server port fails validation."""
+        from dal.scopes.node import Node
+
+        data = {
+            "Type": "ROS1/Nodelet",
+            "PortsInst": {
+                "pubport": {
+                    "Message": "Float32",
+                    "Out": {"out": {"Message": "std_msgs/Float32"}},
+                    "Package": "std_msgs",
+                    "Template": "ROS1/Publisher",
+                }
+            },
+        }
+
+        with pytest.raises(ValueError, match="ROS1/Nodelet nodes must have"):
+            Node.validate_format("Node", data)
+
     def test_validate_ros1_node_nodelet_client_port(self):
         """Test that a ROS1 node with a nodelet client port fails validation."""
         from dal.scopes.node import Node
@@ -200,6 +257,25 @@ class TestNodeSchema:
         }
 
         with pytest.raises(ValueError, match="ROS1/Node nodes cannot have"):
+            Node.validate_format("Node", data)
+
+    def test_validate_server_no_server_port(self):
+        """Test that a MovAI/Server node without an http port fails validation."""
+        from dal.scopes.node import Node
+
+        data = {
+            "Type": "MovAI/Server",
+            "PortsInst": {
+                "pubport": {
+                    "Message": "Float32",
+                    "Out": {"out": {"Message": "std_msgs/Float32"}},
+                    "Package": "std_msgs",
+                    "Template": "ROS1/Publisher",
+                }
+            },
+        }
+
+        with pytest.raises(ValueError, match="MovAI/Server nodes must have"):
             Node.validate_format("Node", data)
 
     def test_validate_ros1_node_http_port(self):


### PR DESCRIPTION
- [BP-1683](https://movai.atlassian.net/browse/BP-1683): We should not be able to create a State Node with only MovAI/Init and MovAI/Exit
  - Tested by importing all studio metadata :heavy_check_mark: 


[BP-1683]: https://movai.atlassian.net/browse/BP-1683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ