### PR TITLE
BP-1684: increase resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
-
+## vTBD
+- [BP-1684](https://movai.atlassian.net/browse/BP-1684): On system load, getting a db client might timeout. Can stop the flow!
 ## v3.24.1
 - [BP-1683](https://movai.atlassian.net/browse/BP-1683): We should not be able to create a State Node with only MovAI/Init and MovAI/Exit
 

--- a/dal/movaidb/database.py
+++ b/dal/movaidb/database.py
@@ -174,7 +174,7 @@ class AioRedisClient(metaclass=Singleton):
         return instance
 
     async def create_redis_pool_with_retry(self, address, retries=3):
-        """ Create a Redis connection pool with retry logic.
+        """Create a Redis connection pool with retry logic.
         Args:
             address (tuple): Redis server address as a tuple (host, port).
             retries (int, optional): Number of retry attempts. Defaults to 3.
@@ -198,7 +198,7 @@ class AioRedisClient(metaclass=Singleton):
                     raise
 
                 # exponential backoff + jitter
-                delay = DB_CONNECT_BASE_DELAY * (2 ** attempt)
+                delay = DB_CONNECT_BASE_DELAY * (2**attempt)
                 delay += random.uniform(0, delay * 0.5)
 
                 LOGGER.warning(
@@ -229,8 +229,7 @@ class AioRedisClient(metaclass=Singleton):
                                 )
                             else:
                                 _conn = await self.create_redis_pool_with_retry(
-                                    address, 
-                                    retries=DB_CONNECT_RETRIES
+                                    address, retries=DB_CONNECT_RETRIES
                                 )
 
                         except Exception as e:

--- a/dal/movaidb/database.py
+++ b/dal/movaidb/database.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, Generator, List, Literal, Optional, Protocol, Tupl
 import aioredis
 import dal
 import redis
+import random
 from deepdiff import DeepDiff
 from redis.client import Pipeline
 from redis.connection import Connection
@@ -30,6 +31,8 @@ from movai_core_shared.logger import Log
 from .db_schema import DBSchema
 
 StrOrDictRecursive = Union[str, None, Dict[str, "StrOrDictRecursive"]]
+DB_CONNECT_RETRIES = 3
+DB_CONNECT_BASE_DELAY = 0.1
 
 LOGGER = Log.get_logger("dal.mov.ai")
 
@@ -170,6 +173,40 @@ class AioRedisClient(metaclass=Singleton):
         await instance._init_databases()
         return instance
 
+    async def create_redis_pool_with_retry(self, address, retries=3):
+        """ Create a Redis connection pool with retry logic.
+        Args:
+            address (tuple): Redis server address as a tuple (host, port).
+            retries (int, optional): Number of retry attempts. Defaults to 3.
+
+        Returns:
+            aioredis.ConnectionsPool: An instance of the Redis connection pool.
+        """
+
+        for attempt in range(retries):
+            try:
+                return await aioredis.create_redis_pool(
+                    address,
+                    minsize=2,
+                    maxsize=100,
+                    timeout=1,
+                    pool_cls=aioredis.ConnectionsPool,
+                )
+
+            except Exception as e:
+                if attempt == retries - 1:
+                    raise
+
+                # exponential backoff + jitter
+                delay = DB_CONNECT_BASE_DELAY * (2 ** attempt)
+                delay += random.uniform(0, delay * 0.5)
+
+                LOGGER.warning(
+                    f"Redis init failed (attempt {attempt+1}/{retries}), retrying in {delay:.2f}s: {e}"
+                )
+
+                await asyncio.sleep(delay)
+
     async def _init_databases(self):
         """will initialize connection pools"""
 
@@ -191,12 +228,9 @@ class AioRedisClient(metaclass=Singleton):
                                     pool_cls=aioredis.ConnectionsPool,
                                 )
                             else:
-                                _conn = await aioredis.create_redis_pool(
-                                    address,
-                                    minsize=2,
-                                    maxsize=100,
-                                    timeout=1,
-                                    pool_cls=aioredis.ConnectionsPool,
+                                _conn = await self.create_redis_pool_with_retry(
+                                    address, 
+                                    retries=DB_CONNECT_RETRIES
                                 )
 
                         except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "data-access-layer"
-version = "3.24.1.1"
+version = "3.24.2.0"
 authors = [
     {name = "Backend team", email = "backend@mov.ai"},
 ]
@@ -64,7 +64,7 @@ dal = [
 line-length = 100
 
 [tool.bumpversion]
-current_version = "3.24.1.1"
+current_version = "3.24.2.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?(\\.(?P<build>\\d+))?"
 serialize = ["{major}.{minor}.{patch}.{build}"]
 


### PR DESCRIPTION
Add retries on tried to get a connection. On system high load this can happen. We have alot of tickets tangled to this. We can try to recover by having some retry attempts with random sleeps that increase on attempt.