### PR TITLE
[EE 2.5.1] have a new attribute of Robot out of Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## vTBD
+- [BP-1675](https://movai.atlassian.net/browse/BP-1621): The Robot().Status["active_scene"] is not set
+
 ## v3.23.0
 - [BP-1621](https://movai.atlassian.net/browse/BP-1621): Setup comms handler on detached spawner side
   - Move init_local_db from flow_initiator to dal

--- a/dal/scopes/robot.py
+++ b/dal/scopes/robot.py
@@ -90,12 +90,15 @@ class Robot(Scope):
         self.__dict__["async_spawner_client"] = AsyncMessageClient(
             server_addr=server, robot_id=self.name
         )
+
     def set_active_scene(self, scene: str):
-        """Set the active scene of the Robot"""
+        """Set the local active scene of the Robot"""
         self.ActiveScene = scene
+
     def get_active_scene(self) -> Optional[str]:
-        """Get the active scene of the Robot"""
+        """Get the local active scene of the Robot"""
         return self.ActiveScene if hasattr(self, "ActiveScene") else "NOT_SET"
+
     def set_ip(self, ip_address: str):
         """Set the IP Adress of the Robot"""
         self.IP = ip_address

--- a/dal/scopes/robot.py
+++ b/dal/scopes/robot.py
@@ -90,7 +90,12 @@ class Robot(Scope):
         self.__dict__["async_spawner_client"] = AsyncMessageClient(
             server_addr=server, robot_id=self.name
         )
-
+    def set_active_scene(self, scene: str):
+        """Set the active scene of the Robot"""
+        self.ActiveScene = scene
+    def get_active_scene(self) -> Optional[str]:
+        """Get the active scene of the Robot"""
+        return self.ActiveScene if hasattr(self, "ActiveScene") else "NOT_SET"
     def set_ip(self, ip_address: str):
         """Set the IP Adress of the Robot"""
         self.IP = ip_address

--- a/dal/validation/redis_schema/1.0/Robot.json
+++ b/dal/validation/redis_schema/1.0/Robot.json
@@ -14,6 +14,7 @@
       "Alerts": "hash",
       "ActiveAlerts": "hash",
       "Status": "hash",
+      "ActiveScene": "str",
       "Parameter": {
         "$name": {
           "Value": "any",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "data-access-layer"
-version = "3.23.0.1"
+version = "3.23.1.0"
 authors = [
     {name = "Backend team", email = "backend@mov.ai"},
 ]
@@ -64,7 +64,7 @@ dal = [
 line-length = 100
 
 [tool.bumpversion]
-current_version = "3.23.0.1"
+current_version = "3.23.1.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?(\\.(?P<build>\\d+))?"
 serialize = ["{major}.{minor}.{patch}.{build}"]
 


### PR DESCRIPTION
Create an attribute active_scene out of the Status.
The status is used by the manager to provide to the IDE active nodes. By having that async function trying to feed the manager, it gets overwritten when redis syncs back. Seperating to a different attribute protects the local logic