### PR TITLE
[2.5.1] Fix spam on releases when in standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
+
+## vTBD
+- [BP-1685](https://movai.atlassian.net/browse/BP-1685): Fix spam on lock release when in standalone
+
 ## v3.23.4
 - [BP-1687](https://movai.atlassian.net/browse/BP-1687): The Robot().Status["active_flow"] is not set
+
 ## v3.23.3
 - [BP-1685](https://movai.atlassian.net/browse/BP-1685): DELETE lock is giving 200 when response is success:false
+
 ## v3.23.2
 - [BP-1684](https://movai.atlassian.net/browse/BP-1684): On system load, getting a db client might timeout. Can stop the flow!
+
 ## v3.23.1
 - [BP-1675](https://movai.atlassian.net/browse/BP-1621): The Robot().Status["active_scene"] is not set
 

--- a/dal/models/lock.py
+++ b/dal/models/lock.py
@@ -19,7 +19,7 @@ from movai_core_shared.logger import Log
 
 from dal.movaidb import MovaiDB
 from dal.scopes.robot import Robot
-
+from dal.scopes.fleetrobot import FleetRobot
 SCOPES = ["local", "global"]
 
 logger = Log.get_logger("Lock")
@@ -253,7 +253,7 @@ class Lock:
             return False
 
         finally:
-            if send_cmd:
+            if not FleetRobot(self.robot_name).is_manager and send_cmd:
                 self.send_unlock_cmd()
 
         return True

--- a/dal/models/lock.py
+++ b/dal/models/lock.py
@@ -20,6 +20,7 @@ from movai_core_shared.logger import Log
 from dal.movaidb import MovaiDB
 from dal.scopes.robot import Robot
 from dal.scopes.fleetrobot import FleetRobot
+
 SCOPES = ["local", "global"]
 
 logger = Log.get_logger("Lock")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dal = [
 line-length = 100
 
 [tool.bumpversion]
-current_version = "3.23.4.2"
+current_version = "3.23.5.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?(\\.(?P<build>\\d+))?"
 serialize = ["{major}.{minor}.{patch}.{build}"]
 


### PR DESCRIPTION
When in standalone, the sending command to spawner, which also tries to release creates alot of spam.