### PR TITLE
[3.0.0] Fix spam on releases when in standalone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## vTBD
+- [BP-1685](https://movai.atlassian.net/browse/BP-1685): Fix spam on lock release when in standalone
+
 ## v3.24.5
 - [BP-1636](https://movai.atlassian.net/browse/BP-1636): ROS2 - Init local DB
 

--- a/dal/models/lock.py
+++ b/dal/models/lock.py
@@ -19,7 +19,7 @@ from movai_core_shared.logger import Log
 
 from dal.movaidb import MovaiDB
 from dal.scopes.robot import Robot
-
+from dal.scopes.fleetrobot import FleetRobot
 SCOPES = ["local", "global"]
 
 logger = Log.get_logger("Lock")
@@ -253,7 +253,7 @@ class Lock:
             return False
 
         finally:
-            if send_cmd:
+            if not FleetRobot(self.robot_name).is_manager and send_cmd:
                 self.send_unlock_cmd()
 
         return True

--- a/dal/models/lock.py
+++ b/dal/models/lock.py
@@ -20,6 +20,7 @@ from movai_core_shared.logger import Log
 from dal.movaidb import MovaiDB
 from dal.scopes.robot import Robot
 from dal.scopes.fleetrobot import FleetRobot
+
 SCOPES = ["local", "global"]
 
 logger = Log.get_logger("Lock")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dal = [
 line-length = 100
 
 [tool.bumpversion]
-current_version = "3.24.5.1"
+current_version = "3.24.6.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?(\\.(?P<build>\\d+))?"
 serialize = ["{major}.{minor}.{patch}.{build}"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "py3rosmsgs==1.18.2",
     "cachetools==5.3.1",
     "astunparse==1.6.3; python_version < '3.9'",
-    "movai-core-shared>=3.10.0.1"
+    "movai-core-shared>=3.10.0.1, <3.11.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
When in standalone, the sending command to spawner, which also tries to release creates alot of spam.