### PR TITLE
BP-1703: FIX Fleet Member With Wrong Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## vTBD
+- [BP-1703](https://movai.atlassian.net/browse/BP-1703): Apply DEVICE_NAME to robot name on init, rather than a temporary name
+
 ## v3.25.0
 - [BP-1673](https://movai.atlassian.net/browse/BP-1673): List mandatory ports based on Node type
 

--- a/dal/scopes/robot.py
+++ b/dal/scopes/robot.py
@@ -54,6 +54,9 @@ class Robot(Scope):
         robot_struct = MovaiDB("local").search_by_args("Robot", Name="*")[0]
 
         if robot_struct:
+            LOGGER.info(
+                f"INITIALIZING ROBOT: Existing Robot found in local db, initializing Robot {robot_struct['Robot']}"
+            )
             for name in robot_struct["Robot"]:
                 super().__init__(scope="Robot", name=name, version="latest", new=False, db="local")
                 try:
@@ -66,7 +69,12 @@ class Robot(Scope):
 
         else:  # no robot exists so lets init one
             unique_id = uuid.uuid4()
-            # print(unique_id.hex)
+            # Use DEVICE_NAME if available to avoid race condition with temporary auto-generated names
+            robot_name = DEVICE_NAME or f"robot_{unique_id.hex[0:6]}"
+            LOGGER.info(
+                f"INITIALIZING ROBOT: No existing Robot found in local db, initializing new Robot {robot_name} with id {unique_id.hex}"
+            )
+
             super().__init__(
                 scope="Robot",
                 name=unique_id.hex,
@@ -74,10 +82,10 @@ class Robot(Scope):
                 new=True,
                 db="local",
             )
-            self.RobotName = "robot_" + unique_id.hex[0:6]
+            self.RobotName = robot_name
 
             self.__dict__["fleet"] = FleetRobot(unique_id.hex, new=True)
-            self.fleet.RobotName = "robot_" + unique_id.hex[0:6]
+            self.fleet.RobotName = robot_name
             self.RobotType = ""
             self.fleet.RobotType = ""
             self.RobotModel = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dal = [
 line-length = 100
 
 [tool.bumpversion]
-current_version = "3.25.0.1"
+current_version = "3.25.1.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)?(\\.(?P<build>\\d+))?"
 serialize = ["{major}.{minor}.{patch}.{build}"]
 


### PR DESCRIPTION
- [BP-1703](https://movai.atlassian.net/browse/BP-1703): Apply DEVICE_NAME to robot name on init, rather than a temporary name



[BP-1703]: https://movai.atlassian.net/browse/BP-1703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ